### PR TITLE
bugfix error messages and years in past century

### DIFF
--- a/src/main/java/com/openlattice/shuttle/dates/JavaDateTimeHelper.java
+++ b/src/main/java/com/openlattice/shuttle/dates/JavaDateTimeHelper.java
@@ -41,17 +41,17 @@ public class JavaDateTimeHelper {
             try {
                 LocalDate ld = LocalDate.parse( date, formatter );
                 if (
-                        datePatterns[0].matches(".*yy.*") && !datePatterns[0].matches(".*yyyy.*") ||
-                                datePatterns[0].matches(".*YY.*") && !datePatterns[0].matches(".*YYYY.*")
-                        ){
-                    if((ld.getYear() - LocalDate.now().getYear())>20){
-                        ld = ld.withYear(ld.getYear()-100);
+                        datePatterns[ 0 ].matches( ".*yy.*" ) && !datePatterns[ 0 ].matches( ".*yyyy.*" ) ||
+                                datePatterns[ 0 ].matches( ".*YY.*" ) && !datePatterns[ 0 ].matches( ".*YYYY.*" )
+                        ) {
+                    if ( ( ld.getYear() - LocalDate.now().getYear() ) > 20 ) {
+                        ld = ld.withYear( ld.getYear() - 100 );
                     }
                 }
                 return ld;
             } catch ( Exception e ) {
-                if (i == datePatterns.length - 1){
-                  logger.error( "Unable to parse date {}, please see debug log for additional information.", date );
+                if ( i == datePatterns.length - 1 ) {
+                    logger.error( "Unable to parse date {}, please see debug log for additional information.", date );
                 }
             }
         }
@@ -68,8 +68,9 @@ public class JavaDateTimeHelper {
 
                 return ldt.atZone( tz.toZoneId() ).toOffsetDateTime();
             } catch ( Exception e ) {
-                if (i == datePatterns.length - 1){
-                  logger.error( "Unable to parse datetime {}, please see debug log for additional information.", date );
+                if ( i == datePatterns.length - 1 ) {
+                    logger.error( "Unable to parse datetime {}, please see debug log for additional information.",
+                            date );
                 }
             }
         }
@@ -86,8 +87,9 @@ public class JavaDateTimeHelper {
 
                 return ldt.atZone( tz.toZoneId() ).toOffsetDateTime();
             } catch ( Exception e ) {
-                if (i == datePatterns.length - 1){
-                  logger.error( "Unable to parse datetime {}, please see debug log for additional information.", date );
+                if ( i == datePatterns.length - 1 ) {
+                    logger.error( "Unable to parse datetime {}, please see debug log for additional information.",
+                            date );
                 }
             }
         }
@@ -102,8 +104,8 @@ public class JavaDateTimeHelper {
             try {
                 return LocalTime.parse( time, formatter );
             } catch ( Exception e ) {
-                if (i == datePatterns.length - 1){
-                  logger.error( "Unable to parse time {}, please see debug log for additional information.", time );
+                if ( i == datePatterns.length - 1 ) {
+                    logger.error( "Unable to parse time {}, please see debug log for additional information.", time );
                 }
             }
         }

--- a/src/main/java/com/openlattice/shuttle/dates/JavaDateTimeHelper.java
+++ b/src/main/java/com/openlattice/shuttle/dates/JavaDateTimeHelper.java
@@ -4,6 +4,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -38,12 +39,19 @@ public class JavaDateTimeHelper {
         for ( int i = 0; i < datePatterns.length; ++i ) {
             DateTimeFormatter formatter = formatters.get( i );
             try {
-                return LocalDate.parse( date, formatter );
+                // transform to simpledateformat (to deal with eg. 95 --> should be 1995 not 2095)
+                SimpleDateFormat frm = new SimpleDateFormat( datePatterns[i] );
+                SimpleDateFormat to = new SimpleDateFormat("dd/MM/yyyy");
+                // transform to YYYY-string
+                String helpstring = to.format(frm.parse(date));
+                DateTimeFormatter frmtr = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+                return LocalDate.parse( helpstring, frmtr );
             } catch ( Exception e ) {
-                logger.error( "Unable to parse date {}, please see debug log for additional information.", date );
+                if (i == datePatterns.length - 1){
+                  logger.error( "Unable to parse date {}, please see debug log for additional information.", date );
+                }
             }
         }
-        logger.error( "Unable to parse date {}, please see debug log for additional information.", date );
         return null;
     }
 
@@ -57,10 +65,11 @@ public class JavaDateTimeHelper {
 
                 return ldt.atZone( tz.toZoneId() ).toOffsetDateTime();
             } catch ( Exception e ) {
-                logger.debug( "Unable to parse datetime {} with format string {}", date, datePatterns[ i ], e );
+                if (i == datePatterns.length - 1){
+                  logger.error( "Unable to parse datetime {}, please see debug log for additional information.", date );
+                }
             }
         }
-        logger.error( "Unable to parse datetime {}, please see debug log for additional information.", date );
         return null;
     }
 
@@ -74,10 +83,11 @@ public class JavaDateTimeHelper {
 
                 return ldt.atZone( tz.toZoneId() ).toOffsetDateTime();
             } catch ( Exception e ) {
-                logger.debug( "Unable to parse date as datetime {} with format string {}", date, datePatterns[ i ], e );
+                if (i == datePatterns.length - 1){
+                  logger.error( "Unable to parse date {}, please see debug log for additional information.", date );
+                }
             }
         }
-        logger.error( "Unable to parse date as datetime {}, please see debug log for additional information.", date );
         return null;
     }
 
@@ -89,10 +99,11 @@ public class JavaDateTimeHelper {
             try {
                 return LocalTime.parse( time, formatter );
             } catch ( Exception e ) {
-                logger.debug( "Unable to parse time {} with format string {}", time, datePatterns[ i ], e );
+                if (i == datePatterns.length - 1){
+                  logger.error( "Unable to parse tim {}, please see debug log for additional information.", time );
+                }
             }
         }
-        logger.error( "Unable to parse time {}, please see debug log for additional information.", time );
         return null;
     }
 

--- a/src/main/java/com/openlattice/shuttle/dates/JavaDateTimeHelper.java
+++ b/src/main/java/com/openlattice/shuttle/dates/JavaDateTimeHelper.java
@@ -39,13 +39,16 @@ public class JavaDateTimeHelper {
         for ( int i = 0; i < datePatterns.length; ++i ) {
             DateTimeFormatter formatter = formatters.get( i );
             try {
-                // transform to simpledateformat (to deal with eg. 95 --> should be 1995 not 2095)
-                SimpleDateFormat frm = new SimpleDateFormat( datePatterns[i] );
-                SimpleDateFormat to = new SimpleDateFormat("dd/MM/yyyy");
-                // transform to YYYY-string
-                String helpstring = to.format(frm.parse(date));
-                DateTimeFormatter frmtr = DateTimeFormatter.ofPattern("dd/MM/yyyy");
-                return LocalDate.parse( helpstring, frmtr );
+                LocalDate ld = LocalDate.parse( date, formatter );
+                if (
+                        datePatterns[0].matches(".*yy.*") && !datePatterns[0].matches(".*yyyy.*") ||
+                                datePatterns[0].matches(".*YY.*") && !datePatterns[0].matches(".*YYYY.*")
+                        ){
+                    if((ld.getYear() - LocalDate.now().getYear())>20){
+                        ld = ld.withYear(ld.getYear()-100);
+                    }
+                }
+                return ld;
             } catch ( Exception e ) {
                 if (i == datePatterns.length - 1){
                   logger.error( "Unable to parse date {}, please see debug log for additional information.", date );
@@ -84,7 +87,7 @@ public class JavaDateTimeHelper {
                 return ldt.atZone( tz.toZoneId() ).toOffsetDateTime();
             } catch ( Exception e ) {
                 if (i == datePatterns.length - 1){
-                  logger.error( "Unable to parse date {}, please see debug log for additional information.", date );
+                  logger.error( "Unable to parse datetime {}, please see debug log for additional information.", date );
                 }
             }
         }
@@ -100,7 +103,7 @@ public class JavaDateTimeHelper {
                 return LocalTime.parse( time, formatter );
             } catch ( Exception e ) {
                 if (i == datePatterns.length - 1){
-                  logger.error( "Unable to parse tim {}, please see debug log for additional information.", time );
+                  logger.error( "Unable to parse time {}, please see debug log for additional information.", time );
                 }
             }
         }


### PR DESCRIPTION
Dates are transformed to simpledateformat and then to localdates, so that years in the previous century are assigned as such.
Also debugged error messages that would appear on all non-matching patterns.