### PR TITLE
applyvalue instead of apply wherever appropriate

### DIFF
--- a/src/main/java/transforms/CaseTransform.java
+++ b/src/main/java/transforms/CaseTransform.java
@@ -57,7 +57,7 @@ public class CaseTransform extends Transformation<String> {
     }
 
     @Override
-    public Object apply( String o ) {
+    public Object applyValue( String o ) {
 
         if ( StringUtils.isBlank( o ) ) {
             return null;

--- a/src/main/java/transforms/DateAsDateTimeTransform.java
+++ b/src/main/java/transforms/DateAsDateTimeTransform.java
@@ -27,7 +27,7 @@ public class DateAsDateTimeTransform extends Transformation<String> {
     }
 
     @Override
-    public Object apply( String o ) {
+    public Object applyValue( String o ) {
         if ( StringUtils.isBlank( o ) | o == null ) {
             return null;
         }

--- a/src/main/java/transforms/DateTimeAsDateTransform.java
+++ b/src/main/java/transforms/DateTimeAsDateTransform.java
@@ -27,7 +27,7 @@ public class DateTimeAsDateTransform extends Transformation<String> {
     }
 
     @Override
-    public Object apply( String o ) {
+    public Object applyValue( String o ) {
         if ( StringUtils.isBlank( o ) | o == null ) {
             return null;
         }

--- a/src/main/java/transforms/DateTimeTransform.java
+++ b/src/main/java/transforms/DateTimeTransform.java
@@ -27,7 +27,7 @@ public class DateTimeTransform extends Transformation<String> {
     }
 
     @Override
-    public Object apply( String o ) {
+    public Object applyValue( String o ) {
         if ( StringUtils.isBlank( o ) | o == null ) {
             return null;
         }

--- a/src/main/java/transforms/DateTransform.java
+++ b/src/main/java/transforms/DateTransform.java
@@ -54,7 +54,7 @@ public class DateTransform extends Transformation<String> {
     }
 
     @Override
-    public Object apply( String o ) {
+    public Object applyValue( String o ) {
         if ( StringUtils.isBlank( o ) | o == null ) {
             return null;
         }

--- a/src/main/java/transforms/GetWeekdayTransform.java
+++ b/src/main/java/transforms/GetWeekdayTransform.java
@@ -49,7 +49,7 @@ public class GetWeekdayTransform extends Transformation<String> {
     }
 
     @Override
-    public Object apply( String o ) {
+    public Object applyValue( String o ) {
         List<String> days = Arrays
                 .asList( "SUNDAY", "MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY", "SATURDAY" );
         String dateStr = getAsString( o );

--- a/src/main/java/transforms/ParseBoolTransform.java
+++ b/src/main/java/transforms/ParseBoolTransform.java
@@ -27,7 +27,7 @@ public class ParseBoolTransform extends Transformation<String> {
     }
 
     @Override
-    public Object apply(String o) {
+    public Object applyValue(String o) {
         if (StringUtils.isNotBlank(o)) {
             try {
                 return convertToBoolean(o);

--- a/src/main/java/transforms/ParseDoubleTransform.java
+++ b/src/main/java/transforms/ParseDoubleTransform.java
@@ -19,7 +19,7 @@ public class ParseDoubleTransform extends Transformation<String> {
     }
 
     @Override
-    public Object apply( String o ) {
+    public Object applyValue( String o ) {
         return Parsers.parseDouble( o );
     }
 

--- a/src/main/java/transforms/ParseImageBase64Transform.java
+++ b/src/main/java/transforms/ParseImageBase64Transform.java
@@ -20,7 +20,7 @@ public class ParseImageBase64Transform extends Transformation<String> {
     public ParseImageBase64Transform() {}
 
     @Override
-    public Object apply( String o ) {
+    public Object applyValue( String o ) {
         return Base64.getEncoder().encode(o.getBytes());
     }
 }

--- a/src/main/java/transforms/ParseIntTransform.java
+++ b/src/main/java/transforms/ParseIntTransform.java
@@ -22,7 +22,7 @@ public class ParseIntTransform extends Transformation<String> {
     }
 
     @Override
-    public Object apply( String o ) {
+    public Object applyValue( String o ) {
         return Parsers.parseInt( o );
     }
 }

--- a/src/main/java/transforms/PrefixTransform.java
+++ b/src/main/java/transforms/PrefixTransform.java
@@ -54,7 +54,7 @@ public class PrefixTransform extends Transformation<String> {
     }
 
     @Override
-    public Object apply( String o ) {
+    public Object applyValue( String o ) {
         if ( StringUtils.isBlank( o ) ) {
             return null;
         }

--- a/src/main/java/transforms/RandomUuidTransform.java
+++ b/src/main/java/transforms/RandomUuidTransform.java
@@ -16,7 +16,7 @@ public class RandomUuidTransform extends Transformation<Map<String, String>> {
     }
 
     @Override
-    public Object apply( Map<String, String> row ) {
+    public Object applyValue( String o ) {
         return UUID.randomUUID().toString();
     }
 }

--- a/src/main/java/transforms/RemoveDigitsTransform.java
+++ b/src/main/java/transforms/RemoveDigitsTransform.java
@@ -43,7 +43,7 @@ public class RemoveDigitsTransform extends Transformation<String> {
     }
 
     @Override
-    public Object apply( String o ) {
+    public Object applyValue( String o ) {
         String outstring = o.replaceAll( "[\\d]+", "" );
         if ( StringUtils.isBlank( outstring ) ) {
             return null;

--- a/src/main/java/transforms/RemovePatternTransform.java
+++ b/src/main/java/transforms/RemovePatternTransform.java
@@ -69,7 +69,7 @@ public class RemovePatternTransform extends Transformation<String> {
     }
 
     @Override
-    public Object apply( String o ) {
+    public Object applyValue( String o ) {
         for ( Pattern rx : rgx ) {
             if ( StringUtils.isBlank( o ) ) {
                 return null;

--- a/src/main/java/transforms/ReplaceRegexTransform.java
+++ b/src/main/java/transforms/ReplaceRegexTransform.java
@@ -27,7 +27,7 @@ public class ReplaceRegexTransform extends Transformation<String> {
     }
 
     @Override
-    public Object apply( String o ) {
+    public Object applyValue( String o ) {
         String outstring = o.replaceAll( target, "" );
         if ( StringUtils.isBlank( o ) ) {
             return null;

--- a/src/main/java/transforms/SubstringTransform.java
+++ b/src/main/java/transforms/SubstringTransform.java
@@ -26,7 +26,7 @@ public class SubstringTransform extends Transformation<String> {
     }
 
     @Override
-    public Object apply( String o ) {
+    public Object applyValue( String o ) {
         final String output;
         if ( StringUtils.isBlank( o ) ) {
             return null;

--- a/src/main/java/transforms/SuffixTransform.java
+++ b/src/main/java/transforms/SuffixTransform.java
@@ -29,7 +29,7 @@ public class SuffixTransform extends Transformation<String> {
     }
 
     @Override
-    public Object apply( String o ) {
+    public Object applyValue( String o ) {
         if ( StringUtils.isBlank( o ) ) {
             return null;
         }

--- a/src/main/java/transforms/TimeTransform.java
+++ b/src/main/java/transforms/TimeTransform.java
@@ -27,7 +27,7 @@ public class TimeTransform extends Transformation<String> {
     }
 
     @Override
-    public Object apply( String o ) {
+    public Object applyValue( String o ) {
         if ( StringUtils.isBlank( o ) | o == null ) {
             return null;
         }

--- a/src/main/java/transforms/ValueTransform.java
+++ b/src/main/java/transforms/ValueTransform.java
@@ -23,7 +23,7 @@ public class ValueTransform extends Transformation<Map<String, String>> {
     }
 
     @Override
-    public Object apply( Map<String, String> row ) {
+    public Object applyValue( String o ) {
         return value;
     }
 }


### PR DESCRIPTION
Before, apply could be applied to both maps and strings, which led to errors.  We implemented applyValue() a while ago, which is called by apply() if a map is inputted.  This PR makes sure applyValue is used wherever possible (i.e. when the input is string)