### PR TITLE
move uploadingExecutor from companion object to Shuttle itself

### DIFF
--- a/src/main/kotlin/com/openlattice/shuttle/Shuttle.kt
+++ b/src/main/kotlin/com/openlattice/shuttle/Shuttle.kt
@@ -65,6 +65,7 @@ import org.slf4j.LoggerFactory
 import java.io.File
 import java.lang.System.exit
 import java.util.*
+import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
@@ -313,9 +314,10 @@ class Shuttle(
         private val integrationDestinations: Map<StorageDestination, IntegrationDestination>,
         private val dataIntegrationApi: DataIntegrationApi
 ) {
+    private val uploadingExecutor =Executors.newSingleThreadExecutor()
+
     companion object {
         private val logger = LoggerFactory.getLogger(Shuttle::class.java)
-        private val uploadingExecutor = Executors.newSingleThreadExecutor()
     }
 
     private val updateTypes = flightPlan.keys.flatMap { flight ->

--- a/src/main/kotlin/com/openlattice/shuttle/Shuttle.kt
+++ b/src/main/kotlin/com/openlattice/shuttle/Shuttle.kt
@@ -65,7 +65,6 @@ import org.slf4j.LoggerFactory
 import java.io.File
 import java.lang.System.exit
 import java.util.*
-import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
@@ -314,7 +313,7 @@ class Shuttle(
         private val integrationDestinations: Map<StorageDestination, IntegrationDestination>,
         private val dataIntegrationApi: DataIntegrationApi
 ) {
-    private val uploadingExecutor =Executors.newSingleThreadExecutor()
+    private val uploadingExecutor = Executors.newSingleThreadExecutor()
 
     companion object {
         private val logger = LoggerFactory.getLogger(Shuttle::class.java)


### PR DESCRIPTION
Weird bug... When uploadingExecutor is in the companion object, and running shuttle integration (without terminating it after) from rehearsal tests, it does not shutdown correctly and second integration never finishes.