### PR TITLE
Don't allow "PRODUCTION" environment

### DIFF
--- a/src/main/kotlin/com/openlattice/data/integration/destinations/S3Destination.kt
+++ b/src/main/kotlin/com/openlattice/data/integration/destinations/S3Destination.kt
@@ -25,7 +25,6 @@ import com.openlattice.data.*
 import com.openlattice.data.integration.*
 import com.openlattice.data.integration.Entity
 import com.openlattice.data.util.PostgresDataHasher
-import com.openlattice.shuttle.MissionControl
 import org.apache.commons.lang3.RandomUtils
 import org.apache.olingo.commons.api.edm.EdmPrimitiveTypeKind
 import org.slf4j.LoggerFactory

--- a/src/main/kotlin/com/openlattice/shuttle/MissionControl.kt
+++ b/src/main/kotlin/com/openlattice/shuttle/MissionControl.kt
@@ -77,7 +77,7 @@ class MissionControl(environment: RetrofitFactory.Environment, authToken: Suppli
 
     companion object {
         private val logger = LoggerFactory.getLogger(MissionControl::class.java)
-        private val client = MissionControl.buildClient(AUTH0_CLIENT_ID)
+        private val client = buildClient(AUTH0_CLIENT_ID)
         private var emailConfiguration: Optional<EmailConfiguration> = Optional.empty()
         private var terminateOnSuccess = true
 
@@ -208,6 +208,9 @@ class MissionControl(environment: RetrofitFactory.Environment, authToken: Suppli
     //by retrofit clients.
     init {
         FullQualifiedNameJacksonSerializer.registerWithMapper(ObjectMappers.getJsonMapper())
+        if ( environment == RetrofitFactory.Environment.PRODUCTION) {
+            fail(-999, Flight.newFlight().done(), Throwable( "PRODUCTION is not a valid integration environment. The valid environments are PROD_INTEGRATION and LOCAL") )
+        }
     }
 
     private val apiClient = ApiClient(environment) { authToken.get() }

--- a/src/main/kotlin/com/openlattice/shuttle/Shuttle.kt
+++ b/src/main/kotlin/com/openlattice/shuttle/Shuttle.kt
@@ -218,7 +218,11 @@ fun main(args: Array<String>) {
     }
 
     environment = if (cl.hasOption(ENVIRONMENT)) {
-        RetrofitFactory.Environment.valueOf(cl.getOptionValue(ENVIRONMENT).toUpperCase())
+        val env = cl.getOptionValue(ENVIRONMENT).toUpperCase()
+        if ("PRODUCTION" == env){
+            MissionControl.fail(-999, flight, Throwable( "PRODUCTION is not a valid integration environment. The valid environments are PROD_INTEGRATION and LOCAL") )
+        }
+        RetrofitFactory.Environment.valueOf(env)
     } else {
         RetrofitFactory.Environment.PRODUCTION
     }

--- a/src/main/kotlin/com/openlattice/shuttle/Shuttle.kt
+++ b/src/main/kotlin/com/openlattice/shuttle/Shuttle.kt
@@ -224,7 +224,7 @@ fun main(args: Array<String>) {
         }
         RetrofitFactory.Environment.valueOf(env)
     } else {
-        RetrofitFactory.Environment.PRODUCTION
+        RetrofitFactory.Environment.PROD_INTEGRATION
     }
 
 

--- a/src/main/kotlin/com/openlattice/shuttle/ShuttleCli.kt
+++ b/src/main/kotlin/com/openlattice/shuttle/ShuttleCli.kt
@@ -81,7 +81,7 @@ class ShuttleCli {
 
         private val environmentOption = Option.builder()
                 .longOpt(ENVIRONMENT)
-                .desc("Specifies an environment to run the integration against. Possible values are LOCAL or PRODUCTION")
+                .desc("Specifies an environment to run the integration against. Possible values are LOCAL or PROD_INTEGRATION")
                 .required(false)
                 .hasArg()
                 .argName("environment")


### PR DESCRIPTION
This PR:
- Causes shuttle to exit when "PRODUCTION" is provided as the target environment
- Updates help messages to reflect "PRODUCTION" as an invalid environment