### PR TITLE
Fix/performance warnings

### DIFF
--- a/src/main/java/com/openlattice/shuttle/Flight.java
+++ b/src/main/java/com/openlattice/shuttle/Flight.java
@@ -19,19 +19,20 @@
 
 package com.openlattice.shuttle;
 
-import com.openlattice.client.serialization.SerializableFunction;
-import com.openlattice.client.serialization.SerializationConstants;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.Maps;
-import com.openlattice.shuttle.conditions.Condition;
+import com.openlattice.client.serialization.SerializableFunction;
+import com.openlattice.client.serialization.SerializationConstants;
 import com.openlattice.shuttle.conditions.ConditionValueMapper;
 import com.openlattice.shuttle.conditions.Conditions;
 import com.openlattice.shuttle.util.Constants;
 
 import java.io.Serializable;
-import java.util.*;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
 
 public class Flight implements Serializable {
 
@@ -55,10 +56,7 @@ public class Flight implements Serializable {
         this.associationDefinitions = associationDefinitions;
 
         if ( condition.isPresent() ) {
-            final List<Condition> internalConditions;
-            internalConditions = new ArrayList<>( this.condition.get().size() + 1 );
-            condition.get().forEach( internalConditions::add );
-            this.valueMapper = new ConditionValueMapper( internalConditions );
+            this.valueMapper = new ConditionValueMapper( condition.get() );
         } else {
             this.valueMapper = null;
         }

--- a/src/main/java/com/openlattice/shuttle/conditions/Condition.java
+++ b/src/main/java/com/openlattice/shuttle/conditions/Condition.java
@@ -7,6 +7,6 @@ import java.util.function.Function;
 import static com.openlattice.shuttle.util.Constants.CONDITIONS;
 
 @JsonTypeInfo( use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = CONDITIONS )
-public abstract class Condition<I extends Object> implements Function<I, Boolean> {
+public abstract class Condition<I> implements Function<I, Boolean> {
     public static final String CONDITION = "@condition";
 }

--- a/src/main/java/com/openlattice/shuttle/conditions/ConditionValueMapper.java
+++ b/src/main/java/com/openlattice/shuttle/conditions/ConditionValueMapper.java
@@ -8,6 +8,10 @@ import java.util.Map;
 public class ConditionValueMapper implements SerializableFunction<Map<String, Object>, Object> {
     private final List<Condition> conditions;
 
+    public ConditionValueMapper( Conditions conditions ) {
+        this.conditions = conditions;
+    }
+
     public ConditionValueMapper( List<Condition> conditions ) {
         this.conditions = conditions;
     }

--- a/src/main/java/com/openlattice/shuttle/conditions/ConditionValueMapper.java
+++ b/src/main/java/com/openlattice/shuttle/conditions/ConditionValueMapper.java
@@ -28,7 +28,7 @@ public class ConditionValueMapper implements SerializableFunction<Map<String, Ob
             } else if ( t.toString().startsWith( "conditions.ConditionalOr" ) ) {
                 schedule = "or";
             } else {
-                Boolean temp = ( (Boolean) t.apply( input ) ).booleanValue();
+                Boolean temp = (Boolean) t.apply( input );
                 if ( schedule == "and" ) {
                     if ( out == null ) {out = temp;} else if ( out ) {out = temp;} else if ( !out ) {}
                 } else if ( schedule == "or" ) {

--- a/src/main/java/com/openlattice/shuttle/conditions/Conditions.java
+++ b/src/main/java/com/openlattice/shuttle/conditions/Conditions.java
@@ -1,35 +1,18 @@
 package com.openlattice.shuttle.conditions;
 
-import com.openlattice.shuttle.transformations.Transformation;
+import com.google.common.collect.Lists;
 
 import java.util.ArrayList;
-import java.util.Collection;
-
-import org.jetbrains.annotations.NotNull;
 
 /**
  * @author Matthew Tamayo-Rios &lt;matthew@openlattice.com&gt;
  */
 public class Conditions extends ArrayList<Condition> {
-    public Conditions( int initialCapacity ) {
-        super( initialCapacity );
-    }
-
-    public Conditions() {
+    private Conditions() {
         super();
     }
 
-    public Conditions(
-            @NotNull
-                    Collection<? extends Condition> c ) {
-        super( c );
-    }
-
     public static Conditions of( Condition... conditions ) {
-        Conditions t = new Conditions( conditions.length );
-        for ( Condition condition : conditions ) {
-            t.add( condition );
-        }
-        return t;
+        return (Conditions) Lists.newArrayList(conditions);
     }
 }

--- a/src/main/java/com/openlattice/shuttle/conditions/Conditions.java
+++ b/src/main/java/com/openlattice/shuttle/conditions/Conditions.java
@@ -1,18 +1,9 @@
 package com.openlattice.shuttle.conditions;
 
-import com.google.common.collect.Lists;
-
 import java.util.ArrayList;
 
 /**
  * @author Matthew Tamayo-Rios &lt;matthew@openlattice.com&gt;
  */
 public class Conditions extends ArrayList<Condition> {
-    private Conditions() {
-        super();
-    }
-
-    public static Conditions of( Condition... conditions ) {
-        return (Conditions) Lists.newArrayList(conditions);
-    }
 }

--- a/src/main/java/com/openlattice/shuttle/edm/EntitySetMetadata.java
+++ b/src/main/java/com/openlattice/shuttle/edm/EntitySetMetadata.java
@@ -19,10 +19,11 @@
 
 package com.openlattice.shuttle.edm;
 
-import com.openlattice.client.serialization.SerializationConstants;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Optional;
+import com.openlattice.client.serialization.SerializationConstants;
+
+import java.util.Optional;
 
 public class EntitySetMetadata {
 

--- a/src/main/java/com/openlattice/shuttle/edm/EntitySetModel.java
+++ b/src/main/java/com/openlattice/shuttle/edm/EntitySetModel.java
@@ -19,13 +19,13 @@
 
 package com.openlattice.shuttle.edm;
 
-import com.openlattice.client.serialization.SerializationConstants;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableSet;
+import com.openlattice.client.serialization.SerializationConstants;
 import org.apache.olingo.commons.api.edm.FullQualifiedName;
 
+import java.util.Optional;
 import java.util.Set;
 
 public class EntitySetModel {
@@ -49,9 +49,9 @@ public class EntitySetModel {
         this.type = new FullQualifiedName( type );
         this.name = name;
         this.title = title;
-        this.description = description.or( "" );
+        this.description = description.orElse( "" );
         this.contacts = contacts;
-        this.owners = owners.or( ImmutableSet::of );
+        this.owners = owners.orElseGet( ImmutableSet::of );
     }
 
     @JsonProperty( SerializationConstants.TYPE_FIELD )

--- a/src/main/java/com/openlattice/shuttle/edm/RequiredProperties.java
+++ b/src/main/java/com/openlattice/shuttle/edm/RequiredProperties.java
@@ -19,15 +19,15 @@
 
 package com.openlattice.shuttle.edm;
 
-import com.openlattice.client.serialization.SerializationConstants;
-import com.openlattice.edm.type.Analyzer;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableSet;
+import com.openlattice.client.serialization.SerializationConstants;
+import com.openlattice.edm.type.Analyzer;
 import org.apache.olingo.commons.api.edm.EdmPrimitiveTypeKind;
 import org.apache.olingo.commons.api.edm.FullQualifiedName;
 
+import java.util.Optional;
 import java.util.Set;
 
 public class RequiredProperties {

--- a/src/main/java/com/openlattice/shuttle/serialization/JacksonLambdaDeserializer.java
+++ b/src/main/java/com/openlattice/shuttle/serialization/JacksonLambdaDeserializer.java
@@ -44,7 +44,7 @@ public class JacksonLambdaDeserializer extends StdDeserializer<SerializableFunct
     private static       Decoder decoder = Base64.getDecoder();
     private static final Encoder encoder = Base64.getEncoder();
 
-    private static final ThreadLocal<Kryo> kryo = new ThreadLocal<Kryo>() {
+    private static final ThreadLocal<Kryo> kryo = new ThreadLocal<>() {
 
         @Override
         protected Kryo initialValue() {

--- a/src/main/java/com/openlattice/shuttle/serialization/JacksonLambdaDeserializer.java
+++ b/src/main/java/com/openlattice/shuttle/serialization/JacksonLambdaDeserializer.java
@@ -44,42 +44,38 @@ public class JacksonLambdaDeserializer extends StdDeserializer<SerializableFunct
     private static       Decoder decoder = Base64.getDecoder();
     private static final Encoder encoder = Base64.getEncoder();
 
-    private static final ThreadLocal<Kryo> kryo = new ThreadLocal<>() {
+    private static final ThreadLocal<Kryo> kryo = ThreadLocal.withInitial( () -> {
 
-        @Override
-        protected Kryo initialValue() {
+        Kryo kryo = new Kryo();
 
-            Kryo kryo = new Kryo();
+        // https://github.com/EsotericSoftware/kryo/blob/master/test/com/esotericsoftware/kryo/serializers/Java8ClosureSerializerTest.java
+        kryo.setInstantiatorStrategy(
+                new Kryo.DefaultInstantiatorStrategy(
+                        new StdInstantiatorStrategy()
+                )
+        );
 
-            // https://github.com/EsotericSoftware/kryo/blob/master/test/com/esotericsoftware/kryo/serializers/Java8ClosureSerializerTest.java
-            kryo.setInstantiatorStrategy(
-                    new Kryo.DefaultInstantiatorStrategy(
-                            new StdInstantiatorStrategy()
-                    )
-            );
+        kryo.register( Object[].class );
+        kryo.register( Class.class );
 
-            kryo.register( Object[].class );
-            kryo.register( Class.class );
+        // Shared Lambdas
+        kryo.register( SerializableFunction.class );
+        kryo.register( SerializedLambda.class );
 
-            // Shared Lambdas
-            kryo.register( SerializableFunction.class );
-            kryo.register( SerializedLambda.class );
+        // always needed for closure serialization, also if
+        // registrationRequired=false
+        kryo.register(
+                ClosureSerializer.Closure.class,
+                new ClosureSerializer()
+        );
 
-            // always needed for closure serialization, also if
-            // registrationRequired=false
-            kryo.register(
-                    ClosureSerializer.Closure.class,
-                    new ClosureSerializer()
-            );
+        kryo.register(
+                Function.class,
+                new ClosureSerializer()
+        );
 
-            kryo.register(
-                    Function.class,
-                    new ClosureSerializer()
-            );
-
-            return kryo;
-        }
-    };
+        return kryo;
+    } );
 
     public static void registerWithMapper( ObjectMapper mapper ) {
 

--- a/src/main/java/com/openlattice/shuttle/serialization/JacksonLambdaSerializer.java
+++ b/src/main/java/com/openlattice/shuttle/serialization/JacksonLambdaSerializer.java
@@ -41,7 +41,7 @@ public class JacksonLambdaSerializer extends StdSerializer<SerializableFunction>
 
     private static final Encoder encoder = Base64.getEncoder();
 
-    private static final ThreadLocal<Kryo> kryo = new ThreadLocal<Kryo>() {
+    private static final ThreadLocal<Kryo> kryo = new ThreadLocal<>() {
 
         @Override
         protected Kryo initialValue() {

--- a/src/main/java/com/openlattice/shuttle/serialization/JacksonLambdaSerializer.java
+++ b/src/main/java/com/openlattice/shuttle/serialization/JacksonLambdaSerializer.java
@@ -41,42 +41,38 @@ public class JacksonLambdaSerializer extends StdSerializer<SerializableFunction>
 
     private static final Encoder encoder = Base64.getEncoder();
 
-    private static final ThreadLocal<Kryo> kryo = new ThreadLocal<>() {
+    private static final ThreadLocal<Kryo> kryo = ThreadLocal.withInitial( () -> {
 
-        @Override
-        protected Kryo initialValue() {
+        Kryo kryo = new Kryo();
 
-            Kryo kryo = new Kryo();
+        // https://github.com/EsotericSoftware/kryo/blob/master/test/com/esotericsoftware/kryo/serializers/Java8ClosureSerializerTest.java
+        kryo.setInstantiatorStrategy(
+                new Kryo.DefaultInstantiatorStrategy(
+                        new StdInstantiatorStrategy()
+                )
+        );
 
-            // https://github.com/EsotericSoftware/kryo/blob/master/test/com/esotericsoftware/kryo/serializers/Java8ClosureSerializerTest.java
-            kryo.setInstantiatorStrategy(
-                    new Kryo.DefaultInstantiatorStrategy(
-                            new StdInstantiatorStrategy()
-                    )
-            );
+        kryo.register( Object[].class );
+        kryo.register( Class.class );
 
-            kryo.register( Object[].class );
-            kryo.register( Class.class );
+        // Shared Lambdas
+        kryo.register( SerializableFunction.class );
+        kryo.register( SerializedLambda.class );
 
-            // Shared Lambdas
-            kryo.register( SerializableFunction.class );
-            kryo.register( SerializedLambda.class );
+        // always needed for closure serialization, also if
+        // registrationRequired=false
+        kryo.register(
+                ClosureSerializer.Closure.class,
+                new ClosureSerializer()
+        );
 
-            // always needed for closure serialization, also if
-            // registrationRequired=false
-            kryo.register(
-                    ClosureSerializer.Closure.class,
-                    new ClosureSerializer()
-            );
+        kryo.register(
+                Function.class,
+                new ClosureSerializer()
+        );
 
-            kryo.register(
-                    Function.class,
-                    new ClosureSerializer()
-            );
-
-            return kryo;
-        }
-    };
+        return kryo;
+    } );
 
     public JacksonLambdaSerializer() {
         super( SerializableFunction.class );

--- a/src/main/java/com/openlattice/shuttle/transformations/BooleanTransformation.java
+++ b/src/main/java/com/openlattice/shuttle/transformations/BooleanTransformation.java
@@ -7,12 +7,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.openlattice.client.serialization.SerializableFunction;
 import com.openlattice.shuttle.util.Constants;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-public class BooleanTransformation<I extends Object> extends Transformation<I> {
+public class BooleanTransformation<I> extends Transformation<I> {
     private final SerializableFunction<Map<String, Object>, Object>              trueValueMapper;
     private final SerializableFunction<Map<String, Object>, Object>              falseValueMapper;
     private final Optional<Transformations>                                      transformsIfTrue;
@@ -34,20 +32,14 @@ public class BooleanTransformation<I extends Object> extends Transformation<I> {
 
         // true valuemapper
         if ( transformsIfTrue.isPresent() ) {
-            final List<Transformation> internalTrueTransforms;
-            internalTrueTransforms = new ArrayList<>( this.transformsIfTrue.get().size() );
-            transformsIfTrue.get().forEach( internalTrueTransforms::add );
-            this.trueValueMapper = new TransformValueMapper( internalTrueTransforms );
+            this.trueValueMapper = new TransformValueMapper( transformsIfTrue.get() );
         } else {
             this.trueValueMapper = row -> null;
         }
 
         // false valuemapper
         if ( transformsIfFalse.isPresent() ) {
-            final List<Transformation> internalFalseTransforms;
-            internalFalseTransforms = new ArrayList<>( this.transformsIfFalse.get().size() );
-            transformsIfFalse.get().forEach( internalFalseTransforms::add );
-            this.falseValueMapper = new TransformValueMapper( internalFalseTransforms );
+            this.falseValueMapper = new TransformValueMapper( transformsIfFalse.get() );
         } else {
             this.falseValueMapper = row -> null;
         }

--- a/src/main/java/com/openlattice/shuttle/transformations/TransformValueMapper.java
+++ b/src/main/java/com/openlattice/shuttle/transformations/TransformValueMapper.java
@@ -46,8 +46,7 @@ public class TransformValueMapper implements SerializableFunction<Map<String, Ob
     public Object apply( Map<String, Object> input ) {
 
         if (transforms.size() == 0){
-            throw new IllegalStateException( String
-                    .format( "At least 1 transformation should be specified (or left blank for columntransform)." ) );
+            throw new IllegalStateException( "At least 1 transformation should be specified (or left blank for columntransform)." );
         }
 
         Object value = input;

--- a/src/main/java/com/openlattice/shuttle/transformations/Transformations.java
+++ b/src/main/java/com/openlattice/shuttle/transformations/Transformations.java
@@ -21,31 +21,10 @@
 
 package com.openlattice.shuttle.transformations;
 
-import com.google.common.collect.Lists;
-import org.jetbrains.annotations.NotNull;
-
 import java.util.ArrayList;
-import java.util.Collection;
 
 /**
  * @author Matthew Tamayo-Rios &lt;matthew@openlattice.com&gt;
  */
 public class Transformations extends ArrayList<Transformation> {
-    public Transformations( int initialCapacity ) {
-        super( initialCapacity );
-    }
-
-    public Transformations() {
-        super();
-    }
-
-    public Transformations(
-            @NotNull
-                    Collection<? extends Transformation> c ) {
-        super( c );
-    }
-
-    public static Transformations of( Transformation... transformations ) {
-        return (Transformations) Lists.newArrayList(transformations);
-    }
 }

--- a/src/main/java/com/openlattice/shuttle/transformations/Transformations.java
+++ b/src/main/java/com/openlattice/shuttle/transformations/Transformations.java
@@ -29,6 +29,10 @@ import java.util.List;
  */
 public class Transformations extends ArrayList<Transformation> {
 
+    public Transformations(){
+        super();
+    }
+
     public Transformations( final List<Transformation> transforms ) {
         super(transforms);
     }

--- a/src/main/java/com/openlattice/shuttle/transformations/Transformations.java
+++ b/src/main/java/com/openlattice/shuttle/transformations/Transformations.java
@@ -22,9 +22,14 @@
 package com.openlattice.shuttle.transformations;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Matthew Tamayo-Rios &lt;matthew@openlattice.com&gt;
  */
 public class Transformations extends ArrayList<Transformation> {
+
+    public Transformations( final List<Transformation> transforms ) {
+        super(transforms);
+    }
 }

--- a/src/main/java/com/openlattice/shuttle/transformations/Transformations.java
+++ b/src/main/java/com/openlattice/shuttle/transformations/Transformations.java
@@ -21,10 +21,11 @@
 
 package com.openlattice.shuttle.transformations;
 
+import com.google.common.collect.Lists;
+import org.jetbrains.annotations.NotNull;
+
 import java.util.ArrayList;
 import java.util.Collection;
-
-import org.jetbrains.annotations.NotNull;
 
 /**
  * @author Matthew Tamayo-Rios &lt;matthew@openlattice.com&gt;
@@ -45,10 +46,6 @@ public class Transformations extends ArrayList<Transformation> {
     }
 
     public static Transformations of( Transformation... transformations ) {
-        Transformations t = new Transformations( transformations.length );
-        for ( Transformation transform : transformations ) {
-            t.add( transform );
-        }
-        return t;
+        return (Transformations) Lists.newArrayList(transformations);
     }
 }

--- a/src/main/java/com/openlattice/shuttle/util/Cached.java
+++ b/src/main/java/com/openlattice/shuttle/util/Cached.java
@@ -17,7 +17,7 @@ public class Cached {
     private static final LoadingCache<String, DateTimeFormatter> formatCache = buildFormatCache();
 
     private static LoadingCache<String, Pattern> buildRegexCache() {
-        return CacheBuilder.newBuilder().build( CacheLoader.from( Pattern::compile ) );
+        return CacheBuilder.newBuilder().build( CacheLoader.from( (key) -> Pattern.compile( key ) ) );
     }
 
     private static LoadingCache<String, Pattern> buildInsensitiveRegexCache() {

--- a/src/main/java/com/openlattice/shuttle/util/Cached.java
+++ b/src/main/java/com/openlattice/shuttle/util/Cached.java
@@ -17,7 +17,7 @@ public class Cached {
     private static final LoadingCache<String, DateTimeFormatter> formatCache = buildFormatCache();
 
     private static LoadingCache<String, Pattern> buildRegexCache() {
-        return CacheBuilder.newBuilder().build( CacheLoader.from( (key) -> Pattern.compile( key ) ) );
+        return CacheBuilder.newBuilder().build( CacheLoader.from( Pattern::compile ) );
     }
 
     private static LoadingCache<String, Pattern> buildInsensitiveRegexCache() {

--- a/src/main/java/com/openlattice/shuttle/util/Parsers.java
+++ b/src/main/java/com/openlattice/shuttle/util/Parsers.java
@@ -1,9 +1,6 @@
 package com.openlattice.shuttle.util;
 
 import org.apache.commons.lang3.StringUtils;
-import org.joda.time.LocalDate;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,7 +28,7 @@ public class Parsers {
                 return Integer.parseInt( intStr );
             } catch ( NumberFormatException e ) {
                 try {
-                    Double d = Double.parseDouble( intStr );
+                    double d = Double.parseDouble( intStr );
                     BigInteger k = BigDecimal.valueOf( d ).toBigInteger();
                     return k.intValue();
                 } catch ( NumberFormatException f ) {

--- a/src/main/java/conditions/BooleanAreNotNullCondition.java
+++ b/src/main/java/conditions/BooleanAreNotNullCondition.java
@@ -5,8 +5,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.openlattice.shuttle.conditions.Condition;
 import com.openlattice.shuttle.util.Constants;
 import org.apache.commons.lang3.StringUtils;
-import transforms.CaseTransform;
-import transforms.ConcatTransform;
 
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/conditions/BooleanAreNotNullCondition.java
+++ b/src/main/java/conditions/BooleanAreNotNullCondition.java
@@ -48,7 +48,7 @@ public class BooleanAreNotNullCondition extends Condition<Map<String, String>> {
 
     @Override
     public Boolean apply( Map<String, String> row ) {
-        Integer count = 0;
+        int count = 0;
         for ( String s : columns ) {
             if ( !( row.containsKey( s ) ) ) {
                 throw new IllegalStateException( String.format( "The column %s is not found.", s ) );
@@ -59,7 +59,7 @@ public class BooleanAreNotNullCondition extends Condition<Map<String, String>> {
             }
         }
 
-        Boolean out = false;
+        boolean out = false;
         switch ( type ) {
             case all:
                 out = count == columns.size();

--- a/src/main/java/conditions/BooleanIsNullCondition.java
+++ b/src/main/java/conditions/BooleanIsNullCondition.java
@@ -7,8 +7,6 @@ import com.openlattice.shuttle.util.Constants;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public class BooleanIsNullCondition extends Condition<Map<String, String>> {
     private final String  column;

--- a/src/main/java/conditions/BooleanRegexCondition.java
+++ b/src/main/java/conditions/BooleanRegexCondition.java
@@ -58,7 +58,7 @@ public class BooleanRegexCondition extends Condition<Map<String, String>> {
 
         Matcher m = Cached.getInsensitiveMatcherForString( o, this.pattern );
 
-        Boolean out = false;
+        boolean out = false;
         if ( m.find() ) {
             out = true;
         }

--- a/src/main/java/conditions/BooleanRegexCondition.java
+++ b/src/main/java/conditions/BooleanRegexCondition.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.openlattice.shuttle.conditions.Condition;
 import com.openlattice.shuttle.util.Cached;
 import com.openlattice.shuttle.util.Constants;
-import org.apache.commons.lang3.StringUtils;
 
 import java.util.Map;
 import java.util.regex.Matcher;

--- a/src/main/java/conditions/CompareCondition.java
+++ b/src/main/java/conditions/CompareCondition.java
@@ -73,7 +73,7 @@ public class CompareCondition extends Condition<Map<String, String>> {
         Object rightTransformed = row.get( rightColumn );
 
         if ( leftColumn == null && rightColumn == null ) {
-            throw new IllegalStateException( String.format( "The comparison is not data dependent. No columns are specified." ) );
+            throw new IllegalStateException( "The comparison is not data dependent. No columns are specified." );
         }
         if ( leftColumn != null && !( row.containsKey( leftColumn ) ) ) {
             throw new IllegalStateException( String.format( "The column %s is not found.", leftColumn ) );

--- a/src/main/java/transforms/BooleanContainsTransform.java
+++ b/src/main/java/transforms/BooleanContainsTransform.java
@@ -2,15 +2,11 @@ package transforms;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.openlattice.client.serialization.SerializableFunction;
-import com.openlattice.shuttle.transformations.TransformValueMapper;
 import com.openlattice.shuttle.transformations.BooleanTransformation;
 import com.openlattice.shuttle.transformations.Transformations;
 import com.openlattice.shuttle.util.Constants;
 import org.apache.commons.lang3.StringUtils;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 

--- a/src/main/java/transforms/BooleanIsNullTransform.java
+++ b/src/main/java/transforms/BooleanIsNullTransform.java
@@ -2,15 +2,11 @@ package transforms;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.openlattice.client.serialization.SerializableFunction;
-import com.openlattice.shuttle.transformations.TransformValueMapper;
 import com.openlattice.shuttle.transformations.BooleanTransformation;
 import com.openlattice.shuttle.transformations.Transformations;
 import com.openlattice.shuttle.util.Constants;
 import org.apache.commons.lang3.StringUtils;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 

--- a/src/main/java/transforms/BooleanPrefixTransform.java
+++ b/src/main/java/transforms/BooleanPrefixTransform.java
@@ -2,15 +2,11 @@ package transforms;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.openlattice.client.serialization.SerializableFunction;
-import com.openlattice.shuttle.transformations.TransformValueMapper;
 import com.openlattice.shuttle.transformations.BooleanTransformation;
 import com.openlattice.shuttle.transformations.Transformations;
 import com.openlattice.shuttle.util.Constants;
 import org.apache.commons.lang3.StringUtils;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 

--- a/src/main/java/transforms/BooleanRegexTransform.java
+++ b/src/main/java/transforms/BooleanRegexTransform.java
@@ -6,7 +6,6 @@ import com.openlattice.shuttle.transformations.BooleanTransformation;
 import com.openlattice.shuttle.transformations.Transformations;
 import com.openlattice.shuttle.util.Cached;
 import com.openlattice.shuttle.util.Constants;
-import org.apache.commons.lang3.StringUtils;
 
 import java.util.Map;
 import java.util.Optional;

--- a/src/main/java/transforms/ColumnTransform.java
+++ b/src/main/java/transforms/ColumnTransform.java
@@ -23,7 +23,6 @@ package transforms;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.SetMultimap;
 import com.openlattice.shuttle.transformations.Transformation;
 import com.openlattice.shuttle.util.Constants;
 

--- a/src/main/java/transforms/CombineDateTimeTransform.java
+++ b/src/main/java/transforms/CombineDateTimeTransform.java
@@ -3,7 +3,6 @@ package transforms;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.openlattice.shuttle.dates.JavaDateTimeHelper;
-import com.openlattice.shuttle.dates.TimeZones;
 import com.openlattice.shuttle.transformations.Transformation;
 import com.openlattice.shuttle.util.Constants;
 import org.apache.commons.lang3.StringUtils;

--- a/src/main/java/transforms/ConcatTransform.java
+++ b/src/main/java/transforms/ConcatTransform.java
@@ -1,7 +1,6 @@
 package transforms;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.openlattice.shuttle.transformations.Transformation;
 import com.openlattice.shuttle.util.Constants;
@@ -9,8 +8,6 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
 import java.util.Map;
-
-import static com.openlattice.shuttle.transformations.Transformation.TRANSFORM;
 
 public class ConcatTransform extends Transformation<Map<String, String>> {
     private final List<String> columns;

--- a/src/main/java/transforms/DateTimeDiffTransform.java
+++ b/src/main/java/transforms/DateTimeDiffTransform.java
@@ -9,7 +9,6 @@ import com.openlattice.shuttle.util.Constants;
 import org.apache.commons.lang3.StringUtils;
 
 import java.math.BigDecimal;
-import java.time.Duration;
 
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;

--- a/src/main/java/transforms/GeocoderTransform.java
+++ b/src/main/java/transforms/GeocoderTransform.java
@@ -9,7 +9,7 @@ import com.openlattice.retrofit.RhizomeJacksonConverterFactory;
 import com.openlattice.rhizome.proxy.RetrofitBuilders;
 import com.openlattice.shuttle.transformations.Transformation;
 import com.openlattice.shuttle.util.Constants;
-import java.io.IOException;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/transforms/GeographyPointTransform.java
+++ b/src/main/java/transforms/GeographyPointTransform.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.openlattice.shuttle.transformations.Transformation;
 import com.openlattice.shuttle.util.Constants;
 import com.openlattice.shuttle.util.Parsers;
-import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/transforms/PaddingTransform.java
+++ b/src/main/java/transforms/PaddingTransform.java
@@ -3,14 +3,10 @@ package transforms;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.openlattice.shuttle.transformations.Transformation;
-import com.openlattice.shuttle.transformations.Transformations;
-import com.openlattice.shuttle.util.Cached;
 import com.openlattice.shuttle.util.Constants;
-import org.apache.commons.lang3.StringUtils;
 
 import java.util.Map;
 import java.util.Optional;
-import java.util.regex.Matcher;
 
 public class PaddingTransform extends Transformation<Map<String, String>> {
     private final String pattern;

--- a/src/main/java/transforms/ParseDoubleTransform.java
+++ b/src/main/java/transforms/ParseDoubleTransform.java
@@ -3,7 +3,6 @@ package transforms;
 import com.openlattice.shuttle.Shuttle;
 import com.openlattice.shuttle.transformations.Transformation;
 import com.openlattice.shuttle.util.Parsers;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/transforms/ParseImageBase64Transform.java
+++ b/src/main/java/transforms/ParseImageBase64Transform.java
@@ -1,13 +1,9 @@
 package transforms;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.openlattice.shuttle.transformations.Transformation;
-import com.openlattice.shuttle.util.Constants;
-import org.apache.commons.lang3.StringUtils;
 
 import java.util.Base64;
-import java.util.Objects;
 
 public class ParseImageBase64Transform extends Transformation<String> {
 

--- a/src/main/java/transforms/ParseIntTransform.java
+++ b/src/main/java/transforms/ParseIntTransform.java
@@ -3,12 +3,8 @@ package transforms;
 import com.openlattice.shuttle.Shuttle;
 import com.openlattice.shuttle.transformations.Transformation;
 import com.openlattice.shuttle.util.Parsers;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.math.BigDecimal;
-import java.math.BigInteger;
 
 public class ParseIntTransform extends Transformation<String> {
 

--- a/src/main/java/transforms/RandomUuidTransform.java
+++ b/src/main/java/transforms/RandomUuidTransform.java
@@ -1,8 +1,6 @@
 package transforms;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.openlattice.shuttle.transformations.Transformation;
-import com.openlattice.shuttle.util.Constants;
 
 import java.util.Map;
 import java.util.UUID;

--- a/src/main/java/transforms/ReplaceTransform.java
+++ b/src/main/java/transforms/ReplaceTransform.java
@@ -54,7 +54,7 @@ public class ReplaceTransform extends Transformation<String> {
     @Override
     public Object applyValue( String o ) {
 
-        Map<String, String> tokens = new HashMap<String, String>();
+        Map<String, String> tokens = new HashMap<>();
         for ( int i = 0; i < target.size(); ++i ) {
             tokens.put( target.get( i ), goal.get( i ) );
         }

--- a/src/main/java/transforms/ReplaceTransform.java
+++ b/src/main/java/transforms/ReplaceTransform.java
@@ -45,7 +45,7 @@ public class ReplaceTransform extends Transformation<String> {
         this.partial = partial.orElse( false );
 
         if ( this.ignoreCase ) {
-            this.target = target.stream().map( value -> value.toLowerCase() ).collect( Collectors.toList() );
+            this.target = target.stream().map( String::toLowerCase ).collect( Collectors.toList() );
         } else {
             this.target = target;
         }

--- a/src/main/java/transforms/ReplaceTransform.java
+++ b/src/main/java/transforms/ReplaceTransform.java
@@ -69,7 +69,7 @@ public class ReplaceTransform extends Transformation<String> {
             sbuild.append( "(?i)" );
         }
         String tokenlist = StringUtils.join( target, "|" );
-        sbuild.append( "(" + tokenlist + ")" );
+        sbuild.append( "(" ).append( tokenlist ).append( ")" );
         if ( !partial ) {
             sbuild.append( "$" );
         }

--- a/src/main/java/transforms/SplitTransform.java
+++ b/src/main/java/transforms/SplitTransform.java
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.openlattice.shuttle.transformations.Transformation;
 import com.openlattice.shuttle.util.Constants;
-import org.apache.commons.lang3.StringUtils;
 
 import java.util.Optional;
 

--- a/src/main/java/transforms/ValueTransform.java
+++ b/src/main/java/transforms/ValueTransform.java
@@ -3,9 +3,7 @@ package transforms;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.openlattice.shuttle.transformations.Transformation;
 import com.openlattice.shuttle.util.Constants;
-import org.apache.commons.lang3.StringUtils;
 
-import java.util.List;
 import java.util.Map;
 
 public class ValueTransform extends Transformation<Map<String, String>> {

--- a/src/main/kotlin/com/openlattice/data/integration/destinations/BaseS3Destination.kt
+++ b/src/main/kotlin/com/openlattice/data/integration/destinations/BaseS3Destination.kt
@@ -22,19 +22,16 @@
 package com.openlattice.data.integration.destinations
 
 import com.geekbeast.util.ExponentialBackoff
-import com.geekbeast.util.Retryable
 import com.geekbeast.util.StopWatch
 import com.geekbeast.util.attempt
 import com.openlattice.data.*
 import com.openlattice.data.integration.*
 import com.openlattice.data.integration.Entity
 import com.openlattice.data.util.PostgresDataHasher
-import org.apache.commons.lang3.RandomUtils
 import org.apache.olingo.commons.api.edm.EdmPrimitiveTypeKind
 import org.slf4j.LoggerFactory
 import java.util.*
 import java.util.stream.Collectors
-import kotlin.math.max
 
 private val logger = LoggerFactory.getLogger(S3Destination::class.java)
 const val MAX_DELAY_MILLIS = 60 * 1000L

--- a/src/main/kotlin/com/openlattice/shuttle/MissionControl.kt
+++ b/src/main/kotlin/com/openlattice/shuttle/MissionControl.kt
@@ -314,9 +314,7 @@ class MissionControl(
     private fun createMissingEntitySets(flightPlan: Map<Flight, Payload>, contacts: Set<String>) {
         flightPlan.keys.forEach {
             it.entities.forEach { entityDefinition ->
-                if (entitySets.containsKey(entityDefinition.entitySetName)) {
-
-                } else {
+                if (!entitySets.containsKey(entityDefinition.entitySetName)) {
                     val fqn = entityDefinition.getEntityTypeFqn()
                     val entitySet = EntitySet(
                             entityDefinition.getId().orElse(UUID.randomUUID()),
@@ -332,9 +330,7 @@ class MissionControl(
                 }
             }
             it.associations.forEach { associationDefinition ->
-                if (entitySets.containsKey(associationDefinition.entitySetName)) {
-
-                } else {
+                if (!entitySets.containsKey(associationDefinition.entitySetName)) {
                     val fqn = associationDefinition.getEntityTypeFqn()
                     val entityTypeId = edmApi.getEntityTypeId(fqn.namespace, fqn.name)
                     val entitySet = EntitySet(

--- a/src/main/kotlin/com/openlattice/shuttle/Shuttle.kt
+++ b/src/main/kotlin/com/openlattice/shuttle/Shuttle.kt
@@ -310,7 +310,7 @@ class Shuttle(
                     .addAll(propertyValueAsCollection)
             properties.getOrPut(propertyId) { mutableSetOf() }.addAll(propertyValueAsCollection)
         }
-        return Pair(properties, addressedProperties);
+        return Pair(properties, addressedProperties)
     }
 
     private fun impulse(flight: Flight, batch: List<Map<String, Any?>>, batchNumber: Long): AddressedDataHolder {

--- a/src/main/kotlin/com/openlattice/shuttle/ShuttleCli.kt
+++ b/src/main/kotlin/com/openlattice/shuttle/ShuttleCli.kt
@@ -156,7 +156,7 @@ fun main(args: Array<String>) {
         cl.hasOption(XML) -> {// get xml payload
             rowColsToPrint = listOf()
             if (cl.hasOption(DATA_ORIGIN)) {
-                val arguments = cl.getOptionValues(DATA_ORIGIN);
+                val arguments = cl.getOptionValues(DATA_ORIGIN)
                 val dataOrigin = when (arguments[0]) {
                     "S3" -> {
                         if (arguments.size < S3_ORIGIN_EXPECTED_ARGS_COUNT) {

--- a/src/main/kotlin/com/openlattice/shuttle/control/IntegrationsService.kt
+++ b/src/main/kotlin/com/openlattice/shuttle/control/IntegrationsService.kt
@@ -1,13 +1,10 @@
 package com.openlattice.shuttle.control
 
 import com.hazelcast.core.HazelcastInstance
-import com.openlattice.data.integration.StorageDestination
 import com.openlattice.edm.EntitySet
 import com.openlattice.edm.type.EntityType
 import com.openlattice.edm.type.PropertyType
 import com.openlattice.hazelcast.HazelcastMap
-import com.openlattice.shuttle.Shuttle
-import com.openlattice.shuttle.payload.JdbcPayload
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
 import org.slf4j.LoggerFactory

--- a/src/main/kotlin/com/openlattice/shuttle/controllers/IntegrationsContoller.kt
+++ b/src/main/kotlin/com/openlattice/shuttle/controllers/IntegrationsContoller.kt
@@ -1,10 +1,6 @@
 package com.openlattice.shuttle.controllers
 
-import com.openlattice.shuttle.control.Integration
 import com.openlattice.shuttle.control.IntegrationsService
-import org.springframework.http.MediaType
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import javax.inject.Inject

--- a/src/main/kotlin/com/openlattice/shuttle/pods/ShuttleMvcPod.kt
+++ b/src/main/kotlin/com/openlattice/shuttle/pods/ShuttleMvcPod.kt
@@ -45,9 +45,9 @@ class ShuttleMvcPod : WebMvcConfigurationSupport() {
 
     protected override fun configureMessageConverters(converters: MutableList<HttpMessageConverter<*>>?) {
         super.addDefaultHttpMessageConverters(converters!!)
-        for (converter in converters!!) {
+        for (converter in converters) {
             if (converter is MappingJackson2HttpMessageConverter) {
-                converter.objectMapper = defaultObjectMapper!!
+                converter.objectMapper = defaultObjectMapper
             }
         }
         converters.add(CsvHttpMessageConverter())

--- a/src/test/java/com/openlattice/shuttle/test/ShuttleTest.java
+++ b/src/test/java/com/openlattice/shuttle/test/ShuttleTest.java
@@ -49,6 +49,7 @@ import transforms.PrefixTransform;
 
 import java.io.IOException;
 import java.net.URL;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -264,7 +265,7 @@ public class ShuttleTest extends ShuttleTestBootstrap {
                         .addProperty(
                                 ALGO_PT.getType().getFullQualifiedNameAsString(),
                                 "algo",
-                                Transformations.of(new PrefixTransform( "COWBELL_" ))  )
+                                new Transformations( Collections.singletonList( new PrefixTransform( "COWBELL_" ) ) )  )
                         .endEntity()
                     .endEntities()
                 .createAssociations()


### PR DESCRIPTION
This PR:
- Fixes a bunch of mechanical warnings
- Removing unused imports
- Removing unnecessary boxing/unboxing
- Uses singletonList for one-element lists
- Uses Java classes instead of Guava for functional constructs
- Fixes compiler warnings for upgrading from Java 5 through Java 8
- Fixes several performance oriented warnings
- Removes unnecessary wrapper types
- Removes unnecessary null checking