### PR TITLE
broaden exception handling to include job OOMs

### DIFF
--- a/src/main/kotlin/com/openlattice/shuttle/ShuttleCli.kt
+++ b/src/main/kotlin/com/openlattice/shuttle/ShuttleCli.kt
@@ -295,7 +295,7 @@ fun main(args: Array<String>) {
         logger.info("Pre-flight check list complete. ")
         shuttle.launch(uploadBatchSize)
         MissionControl.succeed()
-    } catch (ex: Exception) {
+    } catch (ex: Throwable) {
         MissionControl.fail(1, flight, ex)
     }
 }


### PR DESCRIPTION
We're seeing OOMs sometimes in big jobs where images are being pulled from the db, and while we are fixing that, shuttle should properly note the failure.
