### PR TITLE
first localdatetime, then offset

### DIFF
--- a/src/main/kotlin/com/openlattice/shuttle/payload/JdbcPayload.kt
+++ b/src/main/kotlin/com/openlattice/shuttle/payload/JdbcPayload.kt
@@ -61,10 +61,9 @@ private fun read(columns: List<String>, rs: ResultSet): Map<String, Any?> {
         try {
             when (val obj: Any? = rs.getObject(col)) {
                 is ByteArray -> obj
-                is Timestamp -> OffsetDateTime.ofInstant(obj.toInstant(), UTC).toString()
+                is Timestamp -> obj.toLocalDateTime().atZone(UTC).toOffsetDateTime().toString()
                 else -> obj?.toString()
             }
-
         } catch (e: SQLException) {
             logger.error("Unable to read col {}.", col, e)
         }


### PR DESCRIPTION
The previous solution unfortunately still took the local timezone.  This should fix it, f'ing datetimes.

See the comparison of the output in the screenshot:

<img width="1053" alt="Screen Shot 2020-03-16 at 6 47 18 PM" src="https://user-images.githubusercontent.com/7630327/76814056-fdeb8180-67b6-11ea-8fda-bbcc0966af22.png">
