### PR TITLE
Fix S3 XML file integration

### DIFF
--- a/src/main/kotlin/com/openlattice/shuttle/ShuttleCli.kt
+++ b/src/main/kotlin/com/openlattice/shuttle/ShuttleCli.kt
@@ -26,7 +26,8 @@ import com.openlattice.shuttle.ShuttleCliOptions.Companion.POSTGRES
 import com.openlattice.shuttle.ShuttleCliOptions.Companion.PROFILES
 import com.openlattice.shuttle.ShuttleCliOptions.Companion.READ_RATE_LIMIT
 import com.openlattice.shuttle.ShuttleCliOptions.Companion.S3
-import com.openlattice.shuttle.ShuttleCliOptions.Companion.S3_ORIGIN_EXPECTED_ARGS_COUNT
+import com.openlattice.shuttle.ShuttleCliOptions.Companion.S3_ORIGIN_MAXIMUM_ARGS_COUNT
+import com.openlattice.shuttle.ShuttleCliOptions.Companion.S3_ORIGIN_MINIMUM_ARGS_COUNT
 import com.openlattice.shuttle.ShuttleCliOptions.Companion.SERVER
 import com.openlattice.shuttle.ShuttleCliOptions.Companion.SMTP_SERVER
 import com.openlattice.shuttle.ShuttleCliOptions.Companion.SMTP_SERVER_PORT
@@ -158,20 +159,23 @@ fun main(args: Array<String>) {
                 val arguments = cl.getOptionValues(DATA_ORIGIN)
                 val dataOrigin = when (arguments[0]) {
                     "S3" -> {
-                        if (arguments.size < S3_ORIGIN_EXPECTED_ARGS_COUNT) {
+                        if (arguments.size < S3_ORIGIN_MINIMUM_ARGS_COUNT) {
                             println("Not enough arguments provided for S3 data origin, provide AWS region, S3 URL and bucket name")
                             ShuttleCliOptions.printHelp()
                             exitProcess(1)
-                            return
                         }
-                        S3BucketOrigin(arguments[2], makeAWSS3Client(arguments[1]))
+                        val filePrefix = if ( arguments.size == S3_ORIGIN_MAXIMUM_ARGS_COUNT) {
+                            arguments[3]
+                        } else {
+                            ""
+                        }
+                        S3BucketOrigin(arguments[2], makeAWSS3Client(arguments[1]), filePrefix)
                     }
                     "local" -> {
                         if (arguments.size < LOCAL_ORIGIN_EXPECTED_ARGS_COUNT) {
                             println("Not enough arguments provided for local data origin, provide a local file path")
                             ShuttleCliOptions.printHelp()
                             exitProcess(1)
-                            return
                         }
                         LocalFileOrigin(Paths.get(arguments[1]))
                     }
@@ -179,7 +183,6 @@ fun main(args: Array<String>) {
                         println("The specified configuration is invalid ${cl.getOptionValues(DATA_ORIGIN)}")
                         ShuttleCliOptions.printHelp()
                         exitProcess(1)
-                        return
                     }
                 }
                 payload = XmlFilesPayload(dataOrigin)
@@ -191,7 +194,6 @@ fun main(args: Array<String>) {
             System.err.println("At least one valid data origin must be specified.")
             ShuttleCliOptions.printHelp()
             exitProcess(1)
-            return
         }
     }
 

--- a/src/main/kotlin/com/openlattice/shuttle/ShuttleCliOptions.kt
+++ b/src/main/kotlin/com/openlattice/shuttle/ShuttleCliOptions.kt
@@ -57,7 +57,8 @@ class ShuttleCliOptions {
         const val SMTP_SERVER = "smtp-server"
         const val SMTP_SERVER_PORT = "smtp-server-port"
         const val THREADS = "threads"
-        const val S3_ORIGIN_EXPECTED_ARGS_COUNT = 3
+        const val S3_ORIGIN_MAXIMUM_ARGS_COUNT = 4
+        const val S3_ORIGIN_MINIMUM_ARGS_COUNT = 3
         const val LOCAL_ORIGIN_EXPECTED_ARGS_COUNT = 2
 
         private val options = Options()
@@ -104,17 +105,17 @@ class ShuttleCliOptions {
                 .argName("file")
                 .build()
 
-        // --data-origin    S3       region      bucketName
+        // --data-origin    S3       region      bucketName     file prefix or top level folder name
         // --data-origin    local    filepath
         private val dataOriginOption = Option.builder()
                 .longOpt(DATA_ORIGIN)
                 .hasArg(true)
                 .desc("Source location of the data to be integrated\n" +
                         " Current options are:\n" +
-                        "     S3 <S3 endpoint> <AWS Region> <S3 bucket name>\n" +
+                        "     S3 <S3 endpoint> <AWS Region> <S3 bucket name> <folder or file prefix in bucket>\n" +
                         "     local <path to a data file>")
                 .argName("data origin")
-                .numberOfArgs(S3_ORIGIN_EXPECTED_ARGS_COUNT)
+                .numberOfArgs( S3_ORIGIN_MAXIMUM_ARGS_COUNT)
                 .build()
 
         private val datasourceOption = Option.builder()
@@ -167,8 +168,8 @@ class ShuttleCliOptions {
 
         private val xmlOption = Option.builder()
                 .longOpt(XML)
-                .desc("Directory of XML files to use as the datasource for a specific flight.")
-                .hasArg(true)
+                .optionalArg(true)
+                .desc("Directory of XML files to use as the datasource for a specific flight. If --data-origin S3 is provided then this will use the S3 data origin as the source directory")
                 .argName("directory")
                 .build()
 


### PR DESCRIPTION
This PR:
- makes --xml argument parameter optional
- updates data-origin s3 to take a last argument naming a top level folder in the s3 bucket containing target files
- updates data-origin s3 to use said folder to filter files provided to the stream