### PR TITLE
fix Replace/PartialReplace in PostgresDestination

### DIFF
--- a/src/main/kotlin/com/openlattice/shuttle/destinations/PostgresDestination.kt
+++ b/src/main/kotlin/com/openlattice/shuttle/destinations/PostgresDestination.kt
@@ -92,7 +92,7 @@ class PostgresDestination(
                         val partitions = entitySet.partitions.toList()
 
                         val baseVersion = System.currentTimeMillis()
-                        val tombstoneVersion = -baseVersion
+                        val tombstoneVersion = baseVersion
                         val writeVersion = baseVersion + 1
                         val relevantPropertyTypes = entityTypes
                                 .getValue(entitySets.getValue(entitySetId).entityTypeId)


### PR DESCRIPTION
`tombstone` expects a positive version, and takes the negative of what it's passed before it writes