### PR TITLE
add support for aurora

### DIFF
--- a/src/main/kotlin/com/openlattice/shuttle/IntegrationService.kt
+++ b/src/main/kotlin/com/openlattice/shuttle/IntegrationService.kt
@@ -280,8 +280,7 @@ class IntegrationService(
             propertyTypes.mapKeys { it.value.id },
             // TODO: how do we configure writing into aurora?
             DataStoreType.POSTGRES,
-            missionParameters.postgres.config,
-            missionParameters.aurora.config
+            missionParameters
         )
 
         if (s3BucketUrl.isBlank()) {

--- a/src/main/kotlin/com/openlattice/shuttle/IntegrationService.kt
+++ b/src/main/kotlin/com/openlattice/shuttle/IntegrationService.kt
@@ -28,6 +28,7 @@ import com.openlattice.shuttle.destinations.StorageDestination
 import com.openlattice.shuttle.logs.Blackbox
 import com.openlattice.shuttle.payload.JdbcPayload
 import com.openlattice.shuttle.payload.Payload
+import com.openlattice.shuttle.util.DataStoreType
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
@@ -174,6 +175,7 @@ class IntegrationService(
                 null,
                 tableColsToPrint,
                 missionParameters,
+                DataStoreType.NONE,
                 StorageDestination.S3,
                 blackbox,
                 Optional.of(entitySets.getValue(integration.logEntitySetId.get())),

--- a/src/main/kotlin/com/openlattice/shuttle/IntegrationService.kt
+++ b/src/main/kotlin/com/openlattice/shuttle/IntegrationService.kt
@@ -271,8 +271,10 @@ class IntegrationService(
         val s3BucketUrl = integration.s3bucket
         val postgresDataSource = HikariDataSource(HikariConfig(missionParameters.postgres.config))
         val auroraDataSource = HikariDataSource(HikariConfig(missionParameters.aurora.config))
+        val alprDataSource = HikariDataSource(HikariConfig(missionParameters.alpr.config))
         integration.maxConnections.ifPresent { postgresDataSource.maximumPoolSize = it }
         integration.maxConnections.ifPresent { auroraDataSource.maximumPoolSize = it }
+        integration.maxConnections.ifPresent { alprDataSource.maximumPoolSize = it }
 
         val pgDestination = PostgresDestination(
             entitySets.mapKeys { it.value.id },

--- a/src/main/kotlin/com/openlattice/shuttle/MissionControl.kt
+++ b/src/main/kotlin/com/openlattice/shuttle/MissionControl.kt
@@ -254,8 +254,7 @@ class MissionControl(
                 entityTypes,
                 propertyTypes.mapKeys { it.value.id },
                 dataStore,
-                parameters.postgres.config,
-                parameters.aurora.config
+                parameters
             )
 
             destinations[StorageDestination.POSTGRES] = pgDestination

--- a/src/main/kotlin/com/openlattice/shuttle/MissionControl.kt
+++ b/src/main/kotlin/com/openlattice/shuttle/MissionControl.kt
@@ -246,12 +246,13 @@ class MissionControl(
         destinations[StorageDestination.NO_OP] = NoOpDestination()
         val generatePresignedUrlsFun = dataIntegrationApi::generatePresignedUrls
 
-        if (parameters.postgres.enabled) {
+        if (parameters.postgres.enabled || parameters.aurora.enabled) {
+            val pgConfig = if (parameters.postgres.enabled) parameters.postgres.config else parameters.aurora.config
             val pgDestination = PostgresDestination(
                     entitySets.mapKeys { it.value.id },
                     entityTypes,
                     propertyTypes.mapKeys { it.value.id },
-                    HikariDataSource(HikariConfig(parameters.postgres.config))
+                    HikariDataSource(HikariConfig(pgConfig))
             )
 
             destinations[StorageDestination.POSTGRES] = pgDestination

--- a/src/main/kotlin/com/openlattice/shuttle/MissionControl.kt
+++ b/src/main/kotlin/com/openlattice/shuttle/MissionControl.kt
@@ -40,8 +40,6 @@ import com.openlattice.shuttle.destinations.*
 import com.openlattice.shuttle.logs.Blackbox
 import com.openlattice.shuttle.payload.Payload
 import com.openlattice.shuttle.util.DataStoreType
-import com.zaxxer.hikari.HikariConfig
-import com.zaxxer.hikari.HikariDataSource
 import jodd.mail.Email
 import jodd.mail.EmailAddress
 import jodd.mail.MailServer
@@ -250,22 +248,23 @@ class MissionControl(
         val generatePresignedUrlsFun = dataIntegrationApi::generatePresignedUrls
 
         if (dataStore != DataStoreType.NONE) {
-            val pgConfig = if (DataStoreType.AURORA == dataStore)
-                parameters.aurora.config
-            else
-                parameters.postgres.config
+
             val pgDestination = PostgresDestination(
-                    entitySets.mapKeys { it.value.id },
-                    entityTypes,
-                    propertyTypes.mapKeys { it.value.id },
-                    HikariDataSource(HikariConfig(pgConfig))
+                entitySets.mapKeys { it.value.id },
+                entityTypes,
+                propertyTypes.mapKeys { it.value.id },
+                dataStore,
+                parameters.postgres.config,
+                parameters.aurora.config
             )
 
             destinations[StorageDestination.POSTGRES] = pgDestination
 
             if (s3BucketUrl.isNotBlank()) {
                 destinations[StorageDestination.S3] = PostgresS3Destination(
-                        pgDestination, s3Api!!, generatePresignedUrlsFun
+                    pgDestination,
+                    s3Api!!,
+                    generatePresignedUrlsFun
                 )
             }
         } else {

--- a/src/main/kotlin/com/openlattice/shuttle/MissionParameters.kt
+++ b/src/main/kotlin/com/openlattice/shuttle/MissionParameters.kt
@@ -3,6 +3,9 @@ package com.openlattice.shuttle
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.kryptnostic.rhizome.configuration.annotation.ReloadableConfiguration
+import com.openlattice.shuttle.util.DataStoreType
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
 import java.util.*
 
 /**
@@ -17,15 +20,25 @@ data class PostgresConfiguration(
 @ReloadableConfiguration(uri = "shuttle.yaml")
 data class MissionParameters(
     @JsonProperty("postgres") val postgres: PostgresConfiguration,
-    @JsonProperty("aurora") val aurora: PostgresConfiguration
+    @JsonProperty("aurora") val aurora: PostgresConfiguration,
+    @JsonProperty("alpr") val alpr: PostgresConfiguration
 ) {
     companion object {
         @JvmStatic
         fun empty(): MissionParameters {
             return MissionParameters(
                 PostgresConfiguration(Properties()),
+                PostgresConfiguration(Properties()),
                 PostgresConfiguration(Properties())
             )
+        }
+    }
+
+    fun getTargetHikariDataSource(targetDataStore: DataStoreType): HikariDataSource {
+        return when (targetDataStore) {
+            DataStoreType.ALPR -> HikariDataSource(HikariConfig(alpr.config))
+            DataStoreType.AURORA -> HikariDataSource(HikariConfig(aurora.config))
+            else -> HikariDataSource(HikariConfig(postgres.config))
         }
     }
 }

--- a/src/main/kotlin/com/openlattice/shuttle/MissionParameters.kt
+++ b/src/main/kotlin/com/openlattice/shuttle/MissionParameters.kt
@@ -24,4 +24,9 @@ data class MissionParameters(
             return MissionParameters(PostgresConfiguration(false, Properties()))
         }
     }
+    init {
+        require(postgres.enabled xor aurora.enabled) {
+            "only one of \"postgres\", \"aurora\" can be enabled"
+        }
+    }
 }

--- a/src/main/kotlin/com/openlattice/shuttle/MissionParameters.kt
+++ b/src/main/kotlin/com/openlattice/shuttle/MissionParameters.kt
@@ -9,13 +9,14 @@ import java.util.*
  * @author Matthew Tamayo-Rios &lt;matthew@openlattice.com&gt;
  */
 data class PostgresConfiguration(
-        @JsonProperty("enabled") val enabled: Boolean,
-        @JsonProperty("config") val config: Properties
+    @JsonProperty("enabled") val enabled: Boolean,
+    @JsonProperty("config") val config: Properties
 )
 
 @ReloadableConfiguration(uri = "shuttle.yaml")
 data class MissionParameters(
-        @JsonProperty("postgres") val postgres: PostgresConfiguration
+    @JsonProperty("postgres") val postgres: PostgresConfiguration,
+    @JsonProperty("aurora") val aurora: PostgresConfiguration = postgres
 ) {
     companion object {
         @JvmStatic

--- a/src/main/kotlin/com/openlattice/shuttle/MissionParameters.kt
+++ b/src/main/kotlin/com/openlattice/shuttle/MissionParameters.kt
@@ -1,5 +1,6 @@
 package com.openlattice.shuttle
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.kryptnostic.rhizome.configuration.annotation.ReloadableConfiguration
 import java.util.*
@@ -8,25 +9,23 @@ import java.util.*
  *
  * @author Matthew Tamayo-Rios &lt;matthew@openlattice.com&gt;
  */
+@JsonIgnoreProperties(value = ["enabled"])
 data class PostgresConfiguration(
-    @JsonProperty("enabled") val enabled: Boolean,
     @JsonProperty("config") val config: Properties
 )
 
 @ReloadableConfiguration(uri = "shuttle.yaml")
 data class MissionParameters(
     @JsonProperty("postgres") val postgres: PostgresConfiguration,
-    @JsonProperty("aurora") val aurora: PostgresConfiguration = postgres
+    @JsonProperty("aurora") val aurora: PostgresConfiguration
 ) {
     companion object {
         @JvmStatic
         fun empty(): MissionParameters {
-            return MissionParameters(PostgresConfiguration(false, Properties()))
-        }
-    }
-    init {
-        require(postgres.enabled xor aurora.enabled) {
-            "only one of \"postgres\", \"aurora\" can be enabled"
+            return MissionParameters(
+                PostgresConfiguration(Properties()),
+                PostgresConfiguration(Properties())
+            )
         }
     }
 }

--- a/src/main/kotlin/com/openlattice/shuttle/Shuttle.kt
+++ b/src/main/kotlin/com/openlattice/shuttle/Shuttle.kt
@@ -93,7 +93,7 @@ class Shuttle(
     private val integrationDestinations: Map<StorageDestination, IntegrationDestination>,
     private val dataIntegrationApi: DataIntegrationApi?,
     private val tableColsToPrint: Map<Flight, List<String>>,
-    private val parameters: MissionParameters,
+    parameters: MissionParameters,
     private val dataStore: DataStoreType,
     private val binaryDestination: StorageDestination,
     blackbox: Blackbox,
@@ -156,15 +156,13 @@ class Shuttle(
 
             logEntitySet = maybeLogEntitySet.get()
             val logEntityTypeId = logEntitySet.entityTypeId
-            val logDataSource = if (dataStore == DataStoreType.AURORA)
-                HikariDataSource(HikariConfig(parameters.aurora.config))
-            else
-                HikariDataSource(HikariConfig(parameters.postgres.config))
             logsDestination = PostgresDestination(
                 mapOf(logEntitySet.id to logEntitySet),
                 mapOf(logEntityTypeId to entityTypes.getValue(logEntityTypeId)),
                 logProperties.map { logProp -> logProp.value.id to logProp.value }.toMap(),
-                logDataSource
+                dataStore,
+                parameters.postgres.config,
+                parameters.aurora.config
             )
 
         } else {

--- a/src/main/kotlin/com/openlattice/shuttle/Shuttle.kt
+++ b/src/main/kotlin/com/openlattice/shuttle/Shuttle.kt
@@ -161,8 +161,7 @@ class Shuttle(
                 mapOf(logEntityTypeId to entityTypes.getValue(logEntityTypeId)),
                 logProperties.map { logProp -> logProp.value.id to logProp.value }.toMap(),
                 dataStore,
-                parameters.postgres.config,
-                parameters.aurora.config
+                parameters
             )
 
         } else {

--- a/src/main/kotlin/com/openlattice/shuttle/Shuttle.kt
+++ b/src/main/kotlin/com/openlattice/shuttle/Shuttle.kt
@@ -154,7 +154,8 @@ class Shuttle(
 
             logEntitySet = maybeLogEntitySet.get()
             val logEntityTypeId = logEntitySet.entityTypeId
-            val logDataSource = HikariDataSource(HikariConfig(parameters.postgres.config))
+            val pgConfig = if (parameters.postgres.enabled) parameters.postgres.config else parameters.aurora.config
+            val logDataSource = HikariDataSource(HikariConfig(pgConfig))
             logsDestination = PostgresDestination(
                 mapOf(logEntitySet.id to logEntitySet),
                 mapOf(logEntityTypeId to entityTypes.getValue(logEntityTypeId)),
@@ -404,7 +405,7 @@ class Shuttle(
                 propertyDefinition.storageDestination.orElseGet {
                     when (propertyType.datatype) {
                         EdmPrimitiveTypeKind.Binary -> binaryDestination
-                        else -> if (parameters.postgres.enabled) StorageDestination.POSTGRES else StorageDestination.REST
+                        else -> if (parameters.postgres.enabled || parameters.aurora.enabled) StorageDestination.POSTGRES else StorageDestination.REST
                     }
                 }
             }

--- a/src/main/kotlin/com/openlattice/shuttle/ShuttleCli.kt
+++ b/src/main/kotlin/com/openlattice/shuttle/ShuttleCli.kt
@@ -251,7 +251,7 @@ fun main(args: Array<String>) {
     //TODO: Use the right method to select the JWT token for the appropriate environment.
 
     val dataStore = if (cl.hasOption(DATA_STORE))
-        DataStoreType.valueOf(DATA_STORE)
+        DataStoreType.valueOf(cl.getOptionValue(DATA_STORE).uppercase())
     else
         DataStoreType.NONE
 

--- a/src/main/kotlin/com/openlattice/shuttle/ShuttleCliOptions.kt
+++ b/src/main/kotlin/com/openlattice/shuttle/ShuttleCliOptions.kt
@@ -30,37 +30,37 @@ import kotlin.system.exitProcess
  */
 class ShuttleCliOptions {
     companion object {
-        const val HELP = "help"
 
-        const val FLIGHT = "flight"
-        const val USER = "user"
-        const val PASSWORD = "password"
-        const val TOKEN = "token"
-        const val CREATE = "create"
-        const val ENVIRONMENT = "environment"
-        const val SQL = "sql"
-        const val CSV = "csv"
-        const val XML = "xml"
-        const val DATA_ORIGIN = "data-origin"
-        const val DATASOURCE = "datasource"
-        const val FETCHSIZE = "fetchsize"
         const val CONFIGURATION = "config"
-        const val POSTGRES = "postgres"
-        const val AURORA = "aurora"
-        const val PROFILES = "profiles"
-        const val S3 = "s3"
-        const val UPLOAD_SIZE = "upload-size"
-        const val NOTIFICATION_EMAILS = "notify-emails"
+        const val CREATE = "create"
+        const val CSV = "csv"
+        const val DATASOURCE = "datasource"
+        const val DATA_ORIGIN = "data-origin"
+        const val DATA_STORE = "data-store"
+        const val ENVIRONMENT = "environment"
+        const val FETCHSIZE = "fetchsize"
+        const val FLIGHT = "flight"
         const val FROM_EMAIL = "from-email"
         const val FROM_EMAIL_PASSWORD = "from-email-password"
+        const val HELP = "help"
+        const val LOCAL_ORIGIN_EXPECTED_ARGS_COUNT = 2
+        const val NOTIFICATION_EMAILS = "notify-emails"
+        const val PASSWORD = "password"
+        const val PROFILES = "profiles"
         const val READ_RATE_LIMIT = "read-rate-limit"
-        const val SERVER = "server"
-        const val SMTP_SERVER = "smtp-server"
-        const val SMTP_SERVER_PORT = "smtp-server-port"
-        const val THREADS = "threads"
+        const val S3 = "s3"
         const val S3_ORIGIN_MAXIMUM_ARGS_COUNT = 4
         const val S3_ORIGIN_MINIMUM_ARGS_COUNT = 3
-        const val LOCAL_ORIGIN_EXPECTED_ARGS_COUNT = 2
+        const val SERVER = "server"
+        const val SHUTTLE_CONFIG = "shuttle-config"
+        const val SMTP_SERVER = "smtp-server"
+        const val SMTP_SERVER_PORT = "smtp-server-port"
+        const val SQL = "sql"
+        const val THREADS = "threads"
+        const val TOKEN = "token"
+        const val UPLOAD_SIZE = "upload-size"
+        const val USER = "user"
+        const val XML = "xml"
 
         private val options = Options()
         private val clp = DefaultParser()
@@ -188,22 +188,6 @@ class ShuttleCliOptions {
                 .argName("bucket")
                 .build()
 
-        private val postgresOption = Option.builder()
-                .longOpt(POSTGRES)
-                .desc("Bucket and region to be used for postgres configuration")
-                .hasArgs()
-                .argName("bucket,region")
-                .valueSeparator(',')
-                .build()
-
-        private val auroraOption = Option.builder()
-                .longOpt(AURORA)
-                .desc("Bucket and region to be used for aurora configuration")
-                .hasArgs()
-                .argName("bucket,region")
-                .valueSeparator(',')
-                .build()
-
         private val threadsOption = Option.builder()
                 .longOpt(THREADS)
                 .desc("Number of integration threads to use.")
@@ -257,6 +241,20 @@ class ShuttleCliOptions {
                 .argName("Port used to connect to smtp server")
                 .build()
 
+        private val dataStoreOption = Option.builder()
+            .argName(DATA_STORE)
+            .longOpt(DATA_STORE)
+            .desc("target data store to integrate into")
+            .hasArg(true)
+            .build()
+
+        private val shuttleConfigOption = Option.builder()
+            .argName(SHUTTLE_CONFIG)
+            .longOpt(SHUTTLE_CONFIG)
+            .numberOfArgs(2)
+            .desc("S3 bucket and region containing shuttle.yaml")
+            .build()
+
         init {
             options
                     .addOption(helpOption)
@@ -280,12 +278,8 @@ class ShuttleCliOptions {
                     .addOption(smtpServerPortOption)
                     .addOption(threadsOption)
                     .addOption(serverOption)
-
-            options.addOptionGroup(
-                OptionGroup()
-                    .addOption(postgresOption)
-                    .addOption(auroraOption)
-            )
+                    .addOption(dataStoreOption)
+                    .addOption(shuttleConfigOption)
 
             options.addOptionGroup(
                     OptionGroup()

--- a/src/main/kotlin/com/openlattice/shuttle/ShuttleCliOptions.kt
+++ b/src/main/kotlin/com/openlattice/shuttle/ShuttleCliOptions.kt
@@ -46,6 +46,7 @@ class ShuttleCliOptions {
         const val FETCHSIZE = "fetchsize"
         const val CONFIGURATION = "config"
         const val POSTGRES = "postgres"
+        const val AURORA = "aurora"
         const val PROFILES = "profiles"
         const val S3 = "s3"
         const val UPLOAD_SIZE = "upload-size"
@@ -195,6 +196,14 @@ class ShuttleCliOptions {
                 .valueSeparator(',')
                 .build()
 
+        private val auroraOption = Option.builder()
+                .longOpt(AURORA)
+                .desc("Bucket and region to be used for aurora configuration")
+                .hasArgs()
+                .argName("bucket,region")
+                .valueSeparator(',')
+                .build()
+
         private val threadsOption = Option.builder()
                 .longOpt(THREADS)
                 .desc("Number of integration threads to use.")
@@ -269,9 +278,14 @@ class ShuttleCliOptions {
                     .addOption(fromEmailPasswordOption)
                     .addOption(smtpServerOption)
                     .addOption(smtpServerPortOption)
-                    .addOption(postgresOption)
                     .addOption(threadsOption)
                     .addOption(serverOption)
+
+            options.addOptionGroup(
+                OptionGroup()
+                    .addOption(postgresOption)
+                    .addOption(auroraOption)
+            )
 
             options.addOptionGroup(
                     OptionGroup()

--- a/src/main/kotlin/com/openlattice/shuttle/destinations/IntegrationDestination.kt
+++ b/src/main/kotlin/com/openlattice/shuttle/destinations/IntegrationDestination.kt
@@ -22,10 +22,10 @@
 package com.openlattice.shuttle.destinations
 
 import com.openlattice.data.EntityKey
+import com.openlattice.data.PropertyUpdateType
 import com.openlattice.data.UpdateType
 import com.openlattice.data.integration.Association
 import com.openlattice.data.integration.Entity
-import com.openlattice.data.PropertyUpdateType
 import java.util.*
 
 /**
@@ -33,17 +33,18 @@ import java.util.*
  * @author Matthew Tamayo-Rios &lt;matthew@openlattice.com&gt;
  */
 interface IntegrationDestination {
+
     fun integrateEntities(
-            data: Collection<Entity>,
-            entityKeyIds: Map<EntityKey, UUID>,
-            updateTypes: Map<UUID, UpdateType>,
-            propertyUpdateType: Map<UUID,PropertyUpdateType>
+        data: Collection<Entity>,
+        entityKeyIds: Map<EntityKey, UUID>,
+        updateTypes: Map<UUID, UpdateType>,
+        propertyUpdateTypes: Map<UUID, PropertyUpdateType>
     ): Long
 
     fun integrateAssociations(
-            data: Collection<Association>,
-            entityKeyIds: Map<EntityKey, UUID>,
-            updateTypes: Map<UUID, UpdateType>
+        data: Collection<Association>,
+        entityKeyIds: Map<EntityKey, UUID>,
+        updateTypes: Map<UUID, UpdateType>
     ): Long
 
     fun accepts(): StorageDestination

--- a/src/main/kotlin/com/openlattice/shuttle/destinations/NoOpDestination.kt
+++ b/src/main/kotlin/com/openlattice/shuttle/destinations/NoOpDestination.kt
@@ -8,17 +8,20 @@ import com.openlattice.data.integration.Entity
 import java.util.*
 
 class NoOpDestination : IntegrationDestination {
+
     override fun integrateEntities(
-            data: Collection<Entity>,
-            entityKeyIds: Map<EntityKey, UUID>,
-            updateTypes: Map<UUID, UpdateType>,
-            propertyUpdateType: Map<UUID,PropertyUpdateType>
+        data: Collection<Entity>,
+        entityKeyIds: Map<EntityKey, UUID>,
+        updateTypes: Map<UUID, UpdateType>,
+        propertyUpdateTypes: Map<UUID, PropertyUpdateType>
     ): Long {
         return 0
     }
 
     override fun integrateAssociations(
-            data: Collection<Association>, entityKeyIds: Map<EntityKey, UUID>, updateTypes: Map<UUID, UpdateType>
+        data: Collection<Association>,
+        entityKeyIds: Map<EntityKey, UUID>,
+        updateTypes: Map<UUID, UpdateType>
     ): Long {
         return 0
     }

--- a/src/main/kotlin/com/openlattice/shuttle/destinations/PostgresDestination.kt
+++ b/src/main/kotlin/com/openlattice/shuttle/destinations/PostgresDestination.kt
@@ -25,13 +25,9 @@ import com.dataloom.mappers.ObjectMappers
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.google.common.base.Stopwatch
 import com.google.common.collect.ImmutableList
-import com.openlattice.data.DataEdgeKey
-import com.openlattice.data.EntityDataKey
-import com.openlattice.data.EntityKey
-import com.openlattice.data.UpdateType
+import com.openlattice.data.*
 import com.openlattice.data.integration.Association
 import com.openlattice.data.integration.Entity
-import com.openlattice.data.PropertyUpdateType
 import com.openlattice.data.storage.partitions.getPartition
 import com.openlattice.data.storage.updateEntitySql
 import com.openlattice.data.storage.updateVersionsForPropertyTypesInEntitiesInEntitySet
@@ -44,6 +40,8 @@ import com.openlattice.graph.EDGES_UPSERT_SQL
 import com.openlattice.graph.bindColumnsForEdge
 import com.openlattice.postgres.JsonDeserializer
 import com.openlattice.postgres.PostgresArrays
+import com.openlattice.shuttle.util.DataStoreType
+import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
 import org.apache.olingo.commons.api.edm.EdmPrimitiveTypeKind
 import org.slf4j.LoggerFactory
@@ -58,30 +56,41 @@ import java.util.concurrent.TimeUnit
  * @author Matthew Tamayo-Rios &lt;matthew@openlattice.com&gt;
  */
 class PostgresDestination(
-        private val entitySets: Map<UUID, EntitySet>,
-        private val entityTypes: Map<UUID, EntityType>,
-        private val propertyTypes: Map<UUID, PropertyType>,
-        private val hds: HikariDataSource
+    private val entitySets: Map<UUID, EntitySet>,
+    private val entityTypes: Map<UUID, EntityType>,
+    private val propertyTypes: Map<UUID, PropertyType>,
+    private val targetDataStore: DataStoreType,
+    private val postgresConfig: Properties,
+    private val auroraConfig: Properties
 ) : IntegrationDestination {
+
     companion object {
         private val logger = LoggerFactory.getLogger(PostgresDestination::class.java)
         private val mapper = ObjectMappers.newJsonMapper()
     }
 
     override fun integrateEntities(
-            data: Collection<Entity>,
-            entityKeyIds: Map<EntityKey, UUID>,
-            updateTypes: Map<UUID, UpdateType>,
-            propertyUpdateTypes: Map<UUID,PropertyUpdateType>
+        data: Collection<Entity>,
+        entityKeyIds: Map<EntityKey, UUID>,
+        updateTypes: Map<UUID, UpdateType>,
+        propertyUpdateTypes: Map<UUID,PropertyUpdateType>
     ): Long {
 
+        val hds = HikariDataSource(HikariConfig(postgresConfig))
+        val dataHds = if (targetDataStore == DataStoreType.AURORA)
+            HikariDataSource(HikariConfig(auroraConfig))
+        else
+            HikariDataSource(HikariConfig(postgresConfig))
+
         return hds.connection.use { connection ->
-            val sw = Stopwatch.createStarted()
-            val upsertPropertyValues = mutableMapOf<UUID, PreparedStatement>()
-            val updatePropertyValueVersion = connection.prepareStatement(
+            dataHds.connection.use { dataConnection ->
+
+                val sw = Stopwatch.createStarted()
+                val upsertPropertyValues = mutableMapOf<UUID, PreparedStatement>()
+                val updatePropertyValueVersion = dataConnection.prepareStatement(
                     updateVersionsForPropertyTypesInEntitiesInEntitySet()
-            )
-            val count = data
+                )
+                val count = data
                     .groupBy({ it.entitySetId }, { normalize(entityKeyIds, it) })
                     .map { (entitySetId, entities) ->
                         logger.info("Integrating entity set {}", entitySets.getValue(entitySetId).name)
@@ -94,91 +103,97 @@ class PostgresDestination(
                         val tombstoneVersion = baseVersion
                         val writeVersion = baseVersion + 1
                         val relevantPropertyTypes = entityTypes
-                                .getValue(entitySets.getValue(entitySetId).entityTypeId)
-                                .properties
-                                .associateWith(propertyTypes::getValue)
+                            .getValue(entitySets.getValue(entitySetId).entityTypeId)
+                            .properties
+                            .associateWith(propertyTypes::getValue)
                         val propertyTypeIdsArr = when (updateTypes.getValue(entitySetId)) {
-                            UpdateType.Replace -> PostgresArrays.createUuidArray(connection, relevantPropertyTypes.keys)
-                            UpdateType.PartialReplace -> PostgresArrays.createUuidArray(
-                                    connection, data.flatMap { it.details.keys }.toSet()
+                            UpdateType.Replace -> PostgresArrays.createUuidArray(
+                                dataConnection,
+                                relevantPropertyTypes.keys
                             )
-                            else -> PostgresArrays.createUuidArray(connection, setOf())
+                            UpdateType.PartialReplace -> PostgresArrays.createUuidArray(
+                                dataConnection,
+                                data.flatMap { it.details.keys }.toSet()
+                            )
+                            else -> PostgresArrays.createUuidArray(dataConnection, setOf())
                         }
 
                         val writeVersionArray = PostgresArrays.createLongArray(connection, writeVersion)
+                        val writeVersionArrayDataConnection = PostgresArrays.createLongArray(dataConnection, writeVersion)
                         logger.info(
-                                "Preparing queries for entity set {} took {} ms",
-                                entitySets.getValue(entitySetId).name,
-                                esSw.elapsed(TimeUnit.MILLISECONDS)
+                            "Preparing queries for entity set {} took {} ms",
+                            entitySets.getValue(entitySetId).name,
+                            esSw.elapsed(TimeUnit.MILLISECONDS)
                         )
                         val esCount = entities.groupBy { getPartition(it.first, partitions) }
-                                .toSortedMap()
-                                .map { (partition, entityPairs) ->
-                                    val partSw = Stopwatch.createStarted()
-                                    val entityMap = entityPairs.toMap()
-                                    val entityKeyIdsArr = PostgresArrays.createUuidArray(connection, entityMap.keys)
-                                    val partitionArr = PostgresArrays.createIntArray(connection, listOf(partition))
+                            .toSortedMap()
+                            .map { (partition, entityPairs) ->
+                                val partSw = Stopwatch.createStarted()
+                                val entityMap = entityPairs.toMap()
+                                val entityKeyIdsArr = PostgresArrays.createUuidArray(connection, entityMap.keys)
+                                val partitionArr = PostgresArrays.createIntArray(connection, listOf(partition))
 
-                                    when (updateTypes.getValue(entitySetId)) {
-                                        UpdateType.Replace, UpdateType.PartialReplace -> tombstone(
-                                                updatePropertyValueVersion,
-                                                entitySet,
-                                                entityKeyIdsArr,
-                                                partitionArr,
-                                                propertyTypeIdsArr,
-                                                tombstoneVersion
-                                        )
-                                    }
-
-                                    val committedProperties = upsertEntities(
-                                            connection,
-                                            upsertPropertyValues,
-                                            entitySet,
-                                            partition,
-                                            entityMap,
-                                            relevantPropertyTypes,
-                                            writeVersionArray,
-                                            writeVersion,
-                                            propertyUpdateTypes.getValue(entitySetId)
+                                when (updateTypes.getValue(entitySetId)) {
+                                    UpdateType.Replace, UpdateType.PartialReplace -> tombstone(
+                                        updatePropertyValueVersion,
+                                        entitySet,
+                                        entityKeyIdsArr,
+                                        partitionArr,
+                                        propertyTypeIdsArr,
+                                        tombstoneVersion
                                     )
+                                }
 
-                                    logger.info(
-                                            "Upserted $committedProperties properties for partition $partition and entity set {} in {} ms ",
-                                            partition,
+                                val committedProperties = upsertEntities(
+                                    dataConnection,
+                                    upsertPropertyValues,
+                                    entitySet,
+                                    partition,
+                                    entityMap,
+                                    relevantPropertyTypes,
+                                    writeVersionArrayDataConnection,
+                                    writeVersion,
+                                    propertyUpdateTypes.getValue(entitySetId)
+                                )
 
-                                            partSw.elapsed(TimeUnit.MILLISECONDS)
-                                    )
+                                logger.info(
+                                    "Upserted $committedProperties properties for partition $partition and entity set {} in {} ms ",
+                                    partition,
 
-                                    commitEntities(
-                                            connection,
-                                            entitySetId,
-                                            partition,
-                                            entityMap.keys,
-                                            writeVersionArray,
-                                            writeVersion
-                                    )
-                                    val committed = entityMap.size.toLong()
-                                    logger.info(
-                                            "Integrated $committed entities and $committedProperties properties for partition $partition and entity set {} in {} ms",
-                                            entitySets.getValue(entitySetId).name,
-                                            partSw.elapsed(TimeUnit.MILLISECONDS)
-                                    )
-                                    committed
-                                }.sum()
+                                    partSw.elapsed(TimeUnit.MILLISECONDS)
+                                )
+
+                                commitEntities(
+                                    connection,
+                                    entitySetId,
+                                    partition,
+                                    entityMap.keys,
+                                    writeVersionArray,
+                                    writeVersion
+                                )
+                                val committed = entityMap.size.toLong()
+                                logger.info(
+                                    "Integrated $committed entities and $committedProperties properties for partition $partition and entity set {} in {} ms",
+                                    entitySets.getValue(entitySetId).name,
+                                    partSw.elapsed(TimeUnit.MILLISECONDS)
+                                )
+                                committed
+                            }.sum()
                         logger.info(
-                                "Integrated $esCount entities for entity set {} in {} ms",
-                                entitySets.getValue(entitySetId).name,
-                                esSw.elapsed(TimeUnit.MILLISECONDS)
+                            "Integrated $esCount entities for entity set {} in {} ms",
+                            entitySets.getValue(entitySetId).name,
+                            esSw.elapsed(TimeUnit.MILLISECONDS)
                         )
                         esCount
                     }.sum()
 
-            logger.info(
+                logger.info(
                     "Integrated ${data.size} entities and update $count rows in ${sw.elapsed(
-                            TimeUnit.MILLISECONDS
+                        TimeUnit.MILLISECONDS
                     )} ms."
-            )
-            data.size.toLong()
+                )
+                data.size.toLong()
+            }
         }
     }
 
@@ -210,10 +225,16 @@ class PostgresDestination(
     }
 
     internal fun createEdges(keys: Set<DataEdgeKey>): Long {
+
         val partitionsByEntitySet = keys
-                .flatMap { listOf(it.src.entitySetId, it.dst.entitySetId, it.edge.entitySetId) }
-                .toSet()
-                .associateWith { entitySetId -> entitySets.getValue(entitySetId).partitions.toList() }
+            .flatMap { listOf(it.src.entitySetId, it.dst.entitySetId, it.edge.entitySetId) }
+            .toSet()
+            .associateWith { entitySetId -> entitySets.getValue(entitySetId).partitions.toList() }
+
+        val hds = if (targetDataStore == DataStoreType.AURORA)
+            HikariDataSource(HikariConfig(auroraConfig))
+        else
+            HikariDataSource(HikariConfig(postgresConfig))
 
         return hds.connection.use { connection ->
             val ps = connection.prepareStatement(EDGES_UPSERT_SQL)

--- a/src/main/kotlin/com/openlattice/shuttle/util/DataStoreType.kt
+++ b/src/main/kotlin/com/openlattice/shuttle/util/DataStoreType.kt
@@ -1,7 +1,8 @@
 package com.openlattice.shuttle.util
 
 enum class DataStoreType {
-    NONE,
+    ALPR,
     AURORA,
+    NONE,
     POSTGRES
 }

--- a/src/main/kotlin/com/openlattice/shuttle/util/DataStoreType.kt
+++ b/src/main/kotlin/com/openlattice/shuttle/util/DataStoreType.kt
@@ -1,0 +1,7 @@
+package com.openlattice.shuttle.util
+
+enum class DataStoreType {
+    NONE,
+    AURORA,
+    POSTGRES
+}


### PR DESCRIPTION
`--postgres` has been replaced by `--shuttle-config`:

```
--shuttle-config s3-bucket s3-region
```

A new `--data-store` option is available to specify which data store to integrate into:

```
--data-store aurora
--data-store postgres
```

These changes require `shuttle.yaml` to be updated with a new `aurora` entry (identical to `postgres` except for the host).