### PR TITLE
Lattice 2959 archiving

### DIFF
--- a/src/main/java/com/openlattice/shuttle/config/ArchiveConfig.java
+++ b/src/main/java/com/openlattice/shuttle/config/ArchiveConfig.java
@@ -1,0 +1,51 @@
+package com.openlattice.shuttle.config;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Properties;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * @author Andrew Carter andrew@openlattice.com
+ */
+public class ArchiveConfig {
+    private static final Logger logger = LoggerFactory.getLogger( ArchiveYamlMapping.class );
+    private final Properties      hikariConfiguration;
+    private final String          s3Bucket;
+    private final String          s3Region;
+
+    ArchiveConfig(
+            @JsonProperty( "hikariConfig" ) Properties hikariConfiguration,
+            @JsonProperty( "s3Bucket" )             String s3Bucket,
+            @JsonProperty( "s3Region" )             String s3Region
+    ) {
+        this.hikariConfiguration = hikariConfiguration;
+        this.s3Bucket = s3Bucket;
+        this.s3Region = s3Region;
+    }
+
+    @JsonProperty( "hikariConfig" )
+    public Properties getHikariConfiguration() { return hikariConfiguration; }
+
+    @JsonProperty( "s3Bucket" )
+    public String getS3Bucket() { return s3Bucket; }
+
+    @JsonProperty( "s3Region" )
+    public String getS3Region() { return s3Region; }
+
+
+    @JsonIgnore
+    public HikariDataSource getHikariDataSource(String name ) {
+        Properties properties = checkNotNull( (Properties) hikariConfiguration.get( name ), "Hikari configuration does not exist.");
+
+        HikariConfig hc = new HikariConfig( properties );
+        logger.info( "JDBC URL = {}", hc.getJdbcUrl() );
+        return new HikariDataSource( hc );
+    }
+}

--- a/src/main/java/com/openlattice/shuttle/config/ArchiveConfig.java
+++ b/src/main/java/com/openlattice/shuttle/config/ArchiveConfig.java
@@ -13,6 +13,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * @author Andrew Carter andrew@openlattice.com
+ *
+ * Contains connection details (jdbc and s3) for archiving.
  */
 public class ArchiveConfig {
     private static final Logger logger = LoggerFactory.getLogger( ArchiveYamlMapping.class );
@@ -39,13 +41,4 @@ public class ArchiveConfig {
     @JsonProperty( "s3Region" )
     public String getS3Region() { return s3Region; }
 
-
-    @JsonIgnore
-    public HikariDataSource getHikariDataSource(String name ) {
-        Properties properties = checkNotNull( (Properties) hikariConfiguration.get( name ), "Hikari configuration does not exist.");
-
-        HikariConfig hc = new HikariConfig( properties );
-        logger.info( "JDBC URL = {}", hc.getJdbcUrl() );
-        return new HikariDataSource( hc );
-    }
 }

--- a/src/main/java/com/openlattice/shuttle/config/ArchiveConfig.java
+++ b/src/main/java/com/openlattice/shuttle/config/ArchiveConfig.java
@@ -17,7 +17,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * Contains connection details (jdbc and s3) for archiving.
  */
 public class ArchiveConfig {
-    private static final Logger logger = LoggerFactory.getLogger( ArchiveYamlMapping.class );
     private final Properties      hikariConfiguration;
     private final String          s3Bucket;
     private final String          s3Region;

--- a/src/main/java/com/openlattice/shuttle/config/ArchiveConfig.java
+++ b/src/main/java/com/openlattice/shuttle/config/ArchiveConfig.java
@@ -20,15 +20,21 @@ public class ArchiveConfig {
     private final Properties      hikariConfiguration;
     private final String          s3Bucket;
     private final String          s3Region;
+    private final String          accessKey;
+    private final String          secretKey;
 
     ArchiveConfig(
             @JsonProperty( "hikariConfig" ) Properties hikariConfiguration,
             @JsonProperty( "s3Bucket" )             String s3Bucket,
-            @JsonProperty( "s3Region" )             String s3Region
-    ) {
+            @JsonProperty( "s3Region" )             String s3Region,
+            @JsonProperty( "accessKey" )            String accessKey,
+            @JsonProperty( "secretKey" )            String secretKey
+            ) {
         this.hikariConfiguration = hikariConfiguration;
         this.s3Bucket = s3Bucket;
         this.s3Region = s3Region;
+        this.accessKey = accessKey;
+        this.secretKey = secretKey;
     }
 
     @JsonProperty( "hikariConfig" )
@@ -39,5 +45,11 @@ public class ArchiveConfig {
 
     @JsonProperty( "s3Region" )
     public String getS3Region() { return s3Region; }
+
+    @JsonProperty( "accessKey ")
+    public String getAccessKey() { return accessKey; }
+
+    @JsonProperty( "secretKey" )
+    public String getSecretKey() { return secretKey; }
 
 }

--- a/src/main/java/com/openlattice/shuttle/config/ArchiveYamlMapping.java
+++ b/src/main/java/com/openlattice/shuttle/config/ArchiveYamlMapping.java
@@ -15,6 +15,7 @@ public class ArchiveYamlMapping {
     private final String            schemaName;
     private final String            sourceName;
     private final String            destinationName;
+    private final String            dateField;
 
     @JsonCreator
     public ArchiveYamlMapping(
@@ -22,13 +23,15 @@ public class ArchiveYamlMapping {
         @JsonProperty( "dbName" )               String dbName,
         @JsonProperty( "schemaName" )           String schemaName,
         @JsonProperty( "sourceName" )           String sourceName,
-        @JsonProperty( "destinationName" )      String destinationName
+        @JsonProperty( "destinationName" )      String destinationName,
+        @JsonProperty( "dateField" )            String dateField
     ) {
         this.archiveConfig = archiveConfig;
         this.dbName = dbName;
         this.schemaName = schemaName;
         this.sourceName = sourceName;
         this.destinationName = destinationName;
+        this.dateField = dateField;
     }
 
     @JsonProperty( "archiveConfig" )
@@ -45,4 +48,7 @@ public class ArchiveYamlMapping {
 
     @JsonProperty( "destinationName" )
     public String getDestinationName() { return destinationName; }
+
+    @JsonProperty( "dateField" )
+    public String getDateField() { return dateField; }
 }

--- a/src/main/java/com/openlattice/shuttle/config/ArchiveYamlMapping.java
+++ b/src/main/java/com/openlattice/shuttle/config/ArchiveYamlMapping.java
@@ -2,10 +2,12 @@ package com.openlattice.shuttle.config;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.openlattice.shuttle.ArchiveService;
 
 /**
  * @author Andrew Carter andrew@openlattice.com
+ *
+ * Archive configuration files are mapped to this class.
+ * This class contains all fields required to create an ArchiveService.
  */
 public class ArchiveYamlMapping {
     private final ArchiveConfig     archiveConfig;

--- a/src/main/java/com/openlattice/shuttle/config/ArchiveYamlMapping.java
+++ b/src/main/java/com/openlattice/shuttle/config/ArchiveYamlMapping.java
@@ -1,0 +1,46 @@
+package com.openlattice.shuttle.config;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.openlattice.shuttle.ArchiveService;
+
+/**
+ * @author Andrew Carter andrew@openlattice.com
+ */
+public class ArchiveYamlMapping {
+    private final ArchiveConfig     archiveConfig;
+    private final String            dbName;
+    private final String            schemaName;
+    private final String            sourceName;
+    private final String            destinationName;
+
+    @JsonCreator
+    public ArchiveYamlMapping(
+        @JsonProperty( "archiveParameters" )    ArchiveConfig archiveConfig,
+        @JsonProperty( "dbName" )               String dbName,
+        @JsonProperty( "schemaName" )           String schemaName,
+        @JsonProperty( "sourceName" )           String sourceName,
+        @JsonProperty( "destinationName" )      String destinationName
+    ) {
+        this.archiveConfig = archiveConfig;
+        this.dbName = dbName;
+        this.schemaName = schemaName;
+        this.sourceName = sourceName;
+        this.destinationName = destinationName;
+    }
+
+    @JsonProperty( "archiveConfig" )
+    public ArchiveConfig getArchiveConfig() { return archiveConfig; }
+
+    @JsonProperty( "dbName" )
+    public String getDbName() { return dbName; }
+
+    @JsonProperty("schemaName")
+    public String getSchemaName() { return schemaName; }
+
+    @JsonProperty( "sourceName" )
+    public String getSourceName() { return sourceName; }
+
+    @JsonProperty( "destinationName" )
+    public String getDestinationName() { return destinationName; }
+}

--- a/src/main/kotlin/com/openlattice/shuttle/ArchiveConfiguration.kt
+++ b/src/main/kotlin/com/openlattice/shuttle/ArchiveConfiguration.kt
@@ -1,8 +1,0 @@
-package com.openlattice.shuttle
-
-/**
- * @author Andrew Carter andrew@openlattice.com
- */
-class ArchiveConfiguration {
-
-}

--- a/src/main/kotlin/com/openlattice/shuttle/ArchiveConfiguration.kt
+++ b/src/main/kotlin/com/openlattice/shuttle/ArchiveConfiguration.kt
@@ -1,0 +1,8 @@
+package com.openlattice.shuttle
+
+/**
+ * @author Andrew Carter andrew@openlattice.com
+ */
+class ArchiveConfiguration {
+
+}

--- a/src/main/kotlin/com/openlattice/shuttle/ArchiveService.kt
+++ b/src/main/kotlin/com/openlattice/shuttle/ArchiveService.kt
@@ -1,0 +1,113 @@
+package com.openlattice.shuttle
+
+import com.openlattice.organizations.JdbcConnectionParameters
+import com.openlattice.shuttle.config.ArchiveConfig
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import org.joda.time.Days
+import org.slf4j.LoggerFactory
+
+import org.springframework.stereotype.Service
+import java.util.*
+import java.time.temporal.ChronoUnit.DAYS
+import java.sql.Connection
+import java.sql.Statement
+import java.time.LocalDate
+
+/**
+ * @author Andrew Carter andrew@openlattice.com
+ */
+
+//Export
+//1. Accept parameters in shuttle cli
+//2. Validate parameters
+//3. Pass parameters to new class
+//4. New class creates chunks by day or specified duration
+//5. Ensure that s3 is reachable?
+//6. Connect to atlas
+//7. Execute query per day - updating file path and export query per step
+//8. Check if succeeded per step
+//9. Write finished chechpoint
+//10. Validate write succeed by querying s3 to ensure row count matches (per step?)
+
+private val logger = LoggerFactory.getLogger(ArchiveService::class.java)
+
+@Service
+class ArchiveService(
+    private val archiveConfig: ArchiveConfig,
+    private val dbName: String,
+    private val schemaName: String = "openlattice",
+    private val sourceName: String,
+    private val destinationName: String = sourceName
+) {
+    init {
+        logger.info("Initiating ArchiveService...")
+    }
+
+    fun mummify(startDate: LocalDate, days: Int) {
+        logger.info("Beginning mummification...")
+        connectAsSuperuser(dbName).use { connection ->
+            connection.createStatement().use { statement ->
+                generateAndExecuteSqlPerDay(statement, startDate, days, ::exportSql)
+            }
+        }
+    }
+
+    fun exhume(startDate: LocalDate, days: Int) {
+        logger.info("Exhuming data...")
+        connectAsSuperuser(dbName).use { connection ->
+            connection.createStatement().use { statement ->
+                generateAndExecuteSqlPerDay(statement, startDate, days, ::importSql)
+            }
+        }
+    }
+
+    fun generateAndExecuteSqlPerDay(
+        statement: Statement,
+        startDate: LocalDate,
+        days: Int,
+        sqlGenerator: (input: String) -> String
+    ) {
+        for (index in 0 until days) {
+            val currentDate = startDate.plusDays(index.toLong()).toString()
+            val sql = sqlGenerator(currentDate)
+            logger.info("Executing query:\n $sql")
+            if (statement.execute(sql)) {
+                logger.info("Successfully executed query of $currentDate from $sourceName to $destinationName")
+            }
+        }
+    }
+
+    fun connectAsSuperuser(dbName: String): Connection {
+        val config = HikariConfig(archiveConfig.hikariConfiguration)
+        config.jdbcUrl = "${config.jdbcUrl.removeSuffix("/")}/$dbName"
+
+        return HikariDataSource(config).connection
+    }
+
+    fun exportSql(
+        date: String,
+    ): String {
+        return  "SELECT * FROM aws_s3.query_export_to_s3(" +
+                "'SELECT * FROM $schemaName.$sourceName', " +
+                "aws_commons.create_s3_uri(\n" +
+                "   '${archiveConfig.s3Bucket},\n" +
+                "   '$dbName/$schemaName/$destinationName-$date',\n" +
+                "   '${archiveConfig.s3Region}'\n" +
+                "));"
+    }
+
+    fun importSql(
+        date: String,
+    ): String {
+        return " SELECT aws_s3.table_import_from_s3(" +
+                "'$destinationName',\n" +
+                "'', ''," +
+                "aws_commons.create_s3_uri(\n" +
+                "   '${archiveConfig.s3Bucket}',\n" +
+                "   '$dbName/$schemaName/$sourceName-$date',\n" +
+                "   '${archiveConfig.s3Region}'\n" +
+                "));"
+    }
+
+}

--- a/src/main/kotlin/com/openlattice/shuttle/ArchiveService.kt
+++ b/src/main/kotlin/com/openlattice/shuttle/ArchiveService.kt
@@ -21,18 +21,6 @@ const val DEFAULT_DAYS = 1
  * @author Andrew Carter andrew@openlattice.com
  */
 
-//Export
-//1. Accept parameters in shuttle cli
-//2. Validate parameters
-//3. Pass parameters to new class
-//4. New class creates chunks by day or specified duration
-//5. Ensure that s3 is reachable?
-//6. Connect to atlas
-//7. Execute query per day - updating file path and export query per step
-//8. Check if succeeded per step
-//9. Write finished chechpoint
-//10. Validate write succeed by querying s3 to ensure row count matches (per step?)
-
 private val logger = LoggerFactory.getLogger(ArchiveService::class.java)
 
 @Service

--- a/src/main/kotlin/com/openlattice/shuttle/ArchiveService.kt
+++ b/src/main/kotlin/com/openlattice/shuttle/ArchiveService.kt
@@ -22,16 +22,15 @@ import java.time.LocalDate
 
 const val DEFAULT_DAYS = 1
 const val NO_START_DATE = ""
+const val S3_DELIMITER = "/"
+const val S3_MARKER = ""
+const val S3_MAX_KEYS = 1000
 
 /**
  * @author Andrew Carter andrew@openlattice.com
  */
 
 private val logger = LoggerFactory.getLogger(ArchiveService::class.java)
-private val s3Credentials = BasicAWSCredentials(
-    "***",
-    "***"
-)
 
 @Service
 class ArchiveService(
@@ -47,7 +46,12 @@ class ArchiveService(
     init {
         logger.info("Initiating ArchiveService...")
         s3Client = AmazonS3ClientBuilder.standard().withCredentials(
-            AWSStaticCredentialsProvider(s3Credentials)
+            AWSStaticCredentialsProvider(
+                BasicAWSCredentials (
+                    archiveConfig.accessKey,
+                    archiveConfig.secretKey
+                    )
+            )
         ).withRegion(RegionUtils.getRegion(archiveConfig.s3Region).name).build()
     }
 
@@ -184,9 +188,9 @@ class ArchiveService(
         val objectsRequest = ListObjectsRequest(
             archiveConfig.s3Bucket,
             prefix(date),
-            "",
-            "/",
-            1000
+            S3_MARKER,
+            S3_DELIMITER,
+            S3_MAX_KEYS
         )
         try {
             objects = s3Client.listObjects(objectsRequest)

--- a/src/main/kotlin/com/openlattice/shuttle/ArchiveService.kt
+++ b/src/main/kotlin/com/openlattice/shuttle/ArchiveService.kt
@@ -1,17 +1,21 @@
 package com.openlattice.shuttle
 
-import com.openlattice.organizations.JdbcConnectionParameters
+import com.amazonaws.SdkClientException
+import com.amazonaws.auth.AWSStaticCredentialsProvider
+import com.amazonaws.auth.BasicAWSCredentials
+import com.amazonaws.regions.RegionUtils
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.AmazonS3ClientBuilder
+import com.amazonaws.services.s3.model.ObjectListing
 import com.openlattice.shuttle.config.ArchiveConfig
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
-import org.joda.time.Days
 import org.postgresql.util.PSQLException
 import org.slf4j.LoggerFactory
 
 import org.springframework.stereotype.Service
-import java.util.*
-import java.time.temporal.ChronoUnit.DAYS
 import java.sql.Connection
+import java.sql.ResultSet
 import java.sql.Statement
 import java.time.LocalDate
 
@@ -22,6 +26,10 @@ const val DEFAULT_DAYS = 1
  */
 
 private val logger = LoggerFactory.getLogger(ArchiveService::class.java)
+private val s3Credentials = BasicAWSCredentials(
+    "***",
+    "***"
+)
 
 @Service
 class ArchiveService(
@@ -29,83 +37,171 @@ class ArchiveService(
     private val dbName: String,
     private val schemaName: String = "openlattice",
     private val sourceName: String,
-    private val destinationName: String = sourceName
+    private val destinationName: String = sourceName,
+    private val dateField: String // TODO: Add to sql statements once ready to test
 ) {
+    private val s3Client: AmazonS3
+
     init {
         logger.info("Initiating ArchiveService...")
+        s3Client = AmazonS3ClientBuilder.standard().withCredentials(
+            AWSStaticCredentialsProvider(s3Credentials)
+        ).withRegion(RegionUtils.getRegion(archiveConfig.s3Region).name).build()
     }
 
-    // archives data
+    // archive data
+    // overwrite if already exists
     fun mummify(startDate: LocalDate, days: Int) {
         logger.info("Beginning mummification...")
         connectToDatabase(dbName).use { connection ->
             connection.createStatement().use { statement ->
-                generateAndExecuteSqlPerDay(statement, startDate, days, ::exportSql)
+                generateAndExecuteSqlPerDay(statement, startDate, days, ::exportHandler)
             }
         }
     }
 
-    // restores data
+    // restore data
     fun exhume(startDate: LocalDate, days: Int) {
         logger.info("Exhuming data...")
         connectToDatabase(dbName).use { connection ->
             connection.createStatement().use { statement ->
-                generateAndExecuteSqlPerDay(statement, startDate, days, ::importSql)
+                generateAndExecuteSqlPerDay(statement, startDate, days, ::importHandler)
             }
         }
     }
 
-    fun generateAndExecuteSqlPerDay(
+    private fun generateAndExecuteSqlPerDay(
         statement: Statement,
         startDate: LocalDate,
         days: Int,
-        sqlGenerator: (input: String) -> String
+        sqlAndExecuteHandler: (statement: Statement, date: String) -> Unit
     ) {
-        for (index in 0 until days) {
-            val currentDate = startDate.plusDays(index.toLong()).toString()
-            val sql = sqlGenerator(currentDate)
-            logger.info("Executing query:\n $sql")
-            try {
-                statement.execute(sql)
-                logger.info("Successfully executed query of $currentDate from $sourceName to $destinationName")
-            } catch (e: PSQLException) {
-                throw Error("Unsuccessful sql execution", e)
-            }
+        for (dayIndex in 0 until days) {
+            val currentDate = startDate.plusDays(dayIndex.toLong()).toString()
+            sqlAndExecuteHandler(statement, currentDate)
         }
     }
 
-    fun connectToDatabase(dbName: String): Connection {
-        val config = HikariConfig(archiveConfig.hikariConfiguration)
-        // append org database name to the jdbc url
-        config.jdbcUrl = "${config.jdbcUrl.removeSuffix("/")}/$dbName"
-
-        return HikariDataSource(config).connection
+    private fun exportHandler(statement: Statement, currentDate: String) {
+        isOverwrite(currentDate)
+        executeStatement(statement, exportSql(currentDate))
+        validateExport(currentDate)
     }
 
-    // generates sql to invoke an export using aws_s3 postgres extension
-    fun exportSql(
+    private fun importHandler(statement: Statement, currentDate: String) {
+        val parts = countOfS3ObjectsWithPrefix(currentDate)
+        for(part in 0 until parts) {
+            // add one to part to account for 0 vs 1 indexing
+            executeStatement(statement, importSql(currentDate, part + 1))
+        }
+        validateImport(statement,currentDate)
+    }
+
+    // generate sql to invoke an export using aws_s3 postgres extension
+    private fun exportSql(
         date: String,
     ): String {
         return  "SELECT * FROM aws_s3.query_export_to_s3(" +
-                "'SELECT * FROM $schemaName.$sourceName', " +
+                "'SELECT * FROM $schemaName.$sourceName " +
+                "WHERE $dateField = ''$date'' '," +
                 "aws_commons.create_s3_uri(\n" +
-                "   '${archiveConfig.s3Bucket},\n" +
+                "   '${archiveConfig.s3Bucket}',\n" +
                 "   '$dbName/$schemaName/$destinationName-$date',\n" +
                 "   '${archiveConfig.s3Region}'\n" +
                 "));"
     }
 
-    // generates sql to invoke an import using aws_s3 postgres extension
-    fun importSql(
+    // generate sql to invoke an import using aws_s3 postgres extension
+    private fun importSql(
         date: String,
+        part: Int
     ): String {
+        val partString = if (part > 1) "_part$part" else ""
         return " SELECT aws_s3.table_import_from_s3(" +
                 "'$destinationName',\n" +
                 "'', ''," +
                 "aws_commons.create_s3_uri(\n" +
                 "   '${archiveConfig.s3Bucket}',\n" +
-                "   '$dbName/$schemaName/$sourceName-$date',\n" +
+                "   '$dbName/$schemaName/$sourceName-$date$partString',\n" +
                 "   '${archiveConfig.s3Region}'\n" +
                 "));"
+    }
+
+    private fun validateExport(date: String) {
+        if (countOfS3ObjectsWithPrefix(date) > 0) {
+            logger.info("Export validation succeeded. Data written to s3.")
+        } else {
+            logger.error("Export validation failed: no data written was written to s3. " +
+                    "Either there was a problem exporting or there is no data in the source table.")
+        }
+    }
+
+    private fun validateImport(statement: Statement, date: String) {
+        val query = "SELECT count(*) count " +
+                "FROM $destinationName " +
+                "WHERE $dateField = '$date';"
+        val resultSet = executeStatement(statement, query)
+        resultSet.next()
+        val numRowsWritten = resultSet.getInt(1)
+        if (numRowsWritten > 0) {
+            logger.info("Import validation succeeded. $numRowsWritten rows found in $destinationName for $date.")
+        } else {
+            logger.error("Import validation failed: no data written was written to $destinationName. " +
+                    "Either there was a problem importing or there is no data in the source.")
+        }
+    }
+
+    // TODO: Refactor into init to establish the connection asap?
+    private fun connectToDatabase(dbName: String): Connection {
+        val config = HikariConfig(archiveConfig.hikariConfiguration)
+        // append org database name to the jdbc url
+        config.jdbcUrl = "${config.jdbcUrl.removeSuffix("/")}/$dbName"
+        try {
+            return HikariDataSource(config).connection
+        } catch(e: Exception) {
+            throw Error("Error connecting with HikariDataSource...", e)
+        }
+    }
+
+    fun executeStatement(statement: Statement, sql: String): ResultSet {
+        logger.info("Executing query:\n $sql")
+        try {
+            val rs = statement.executeQuery(sql)
+            logger.info("Successfully executed query.")
+            return rs
+        } catch (e: PSQLException) {
+            throw Error("Unsuccessful sql execution of $sql", e)
+        }
+    }
+
+    private fun isOverwrite(date: String) {
+        val count = countOfS3ObjectsWithPrefix(date)
+        if (count > 0) {
+            logger.info("Overwriting. Number of existing objects in s3 with prefix ${prefix(date)}: $count")
+        } else {
+            logger.info("Creating new objects. No objects exist in s3 with prefix ${prefix(date)}")
+        }
+    }
+
+    private fun countOfS3ObjectsWithPrefix(date: String): Int {
+        val objects: ObjectListing
+        try {
+            objects = s3Client.listObjects(archiveConfig.s3Bucket, prefix(date))
+        } catch (e: SdkClientException) {
+            throw Exception(e)
+        }
+        if (objects.isTruncated) {
+            // TODO: Provide support for truncated result
+            throw Exception("Too many objects with prefix ${prefix()}. Truncated ObjectListing not supported.")
+        }
+        return objects.objectSummaries.size
+    }
+
+    private fun prefix(): String {
+        return "$dbName/$schemaName/$sourceName"
+    }
+
+    private fun prefix(date: String): String {
+        return "$dbName/$schemaName/$sourceName-$date"
     }
 }

--- a/src/main/kotlin/com/openlattice/shuttle/ShuttleCli.kt
+++ b/src/main/kotlin/com/openlattice/shuttle/ShuttleCli.kt
@@ -89,7 +89,7 @@ fun main(args: Array<String>) {
     }
 
     if (cl.hasOption(ARCHIVE)) {
-        if (cl.hasOption(CONFIGURATION) && cl.hasOption(START_DATE)) {
+        if (cl.hasOption(CONFIGURATION)) {
 
             val archiveYamlMapping = try {
                 ObjectMappers.getYamlMapper()
@@ -110,6 +110,14 @@ fun main(args: Array<String>) {
             } else {
                 DEFAULT_DAYS
             }
+
+            val startDate = if (cl.hasOption(START_DATE)) {
+                cl.getOptionValue(START_DATE)
+            } else {
+                logger.info("No start date provided.")
+                NO_START_DATE
+            }
+
             val archiver = ArchiveService(
                 archiveYamlMapping.archiveConfig,
                 archiveYamlMapping.dbName,
@@ -119,18 +127,26 @@ fun main(args: Array<String>) {
                 archiveYamlMapping.dateField
             )
 
-            if (cl.hasOption(EXPORT)) {
+            val archiveOption = cl.getOptionValue(ARCHIVE)
+
+            if (archiveOption.equals(EXPORT)) {
                 archiver.mummify(
-                    LocalDate.parse(cl.getOptionValue(START_DATE)),
+                    startDate,
                     days
                 )
-            } else if (cl.hasOption(IMPORT)) {
+            } else if (archiveOption.equals(IMPORT)) {
                 archiver.exhume(
-                    LocalDate.parse(cl.getOptionValue(START_DATE)),
+                    startDate,
                     days
                 )
-            } else { printErrorHelpAndExit("Export or import option must be specified.") }
-        } else { printErrorHelpAndExit("Archive specified but either config or start_date missing.") }
+            } else {
+                logger.error("Export or import option must be specified with archive. \n\t--archive import\n\t--archive export")
+                exitProcess(1)
+            }
+        } else {
+            logger.error("Archive specified, but config yaml file not provided. \n\t--config /path/to/file.yaml")
+            exitProcess(1)
+        }
         return
     }
 

--- a/src/main/kotlin/com/openlattice/shuttle/ShuttleCli.kt
+++ b/src/main/kotlin/com/openlattice/shuttle/ShuttleCli.kt
@@ -115,7 +115,8 @@ fun main(args: Array<String>) {
                 archiveYamlMapping.dbName,
                 archiveYamlMapping.schemaName,
                 archiveYamlMapping.sourceName,
-                archiveYamlMapping.destinationName
+                archiveYamlMapping.destinationName,
+                archiveYamlMapping.dateField
             )
 
             if (cl.hasOption(EXPORT)) {

--- a/src/main/kotlin/com/openlattice/shuttle/ShuttleCli.kt
+++ b/src/main/kotlin/com/openlattice/shuttle/ShuttleCli.kt
@@ -108,7 +108,7 @@ fun main(args: Array<String>) {
             val days = if (cl.hasOption(DAYS)) {
                 cl.getOptionValue(DAYS).toInt()
             } else {
-                1
+                DEFAULT_DAYS
             }
             val archiver = ArchiveService(
                 archiveYamlMapping.archiveConfig,

--- a/src/main/kotlin/com/openlattice/shuttle/ShuttleCliOptions.kt
+++ b/src/main/kotlin/com/openlattice/shuttle/ShuttleCliOptions.kt
@@ -60,6 +60,11 @@ class ShuttleCliOptions {
         const val S3_ORIGIN_MAXIMUM_ARGS_COUNT = 4
         const val S3_ORIGIN_MINIMUM_ARGS_COUNT = 3
         const val LOCAL_ORIGIN_EXPECTED_ARGS_COUNT = 2
+        const val ARCHIVE = "archive"
+        const val START_DATE = "start-date"
+        const val DAYS = "days"
+        const val EXPORT = "export"
+        const val IMPORT = "import"
 
         private val options = Options()
         private val clp = DefaultParser()
@@ -248,6 +253,41 @@ class ShuttleCliOptions {
                 .argName("Port used to connect to smtp server")
                 .build()
 
+        private val archiveOption = Option.builder()
+            .longOpt(ARCHIVE)
+            .hasArg(false)
+            .desc("Archive or import data between jdbc and s3")
+            .argName("archive")
+            .build()
+
+        private val startDateOption = Option.builder()
+            .longOpt(START_DATE)
+            .hasArg(true)
+            .desc("Indicate date to begin archiving data (inclusive beginning at 00:00)")
+            .argName("start date")
+            .build()
+
+        private val daysOption = Option.builder()
+            .longOpt(DAYS)
+            .hasArg(true)
+            .desc("Indicates number of days from startDate to archive. Includes start date.")
+            .argName("days")
+            .build()
+
+        private val exportOption = Option.builder()
+            .longOpt(EXPORT)
+            .hasArg(false)
+            .desc("Indicates export for archival")
+            .argName("export-archive")
+            .build()
+
+        private val importOption = Option.builder()
+            .longOpt(IMPORT)
+            .hasArg(false)
+            .desc("Indicates import for archival")
+            .argName("import-archive")
+            .build()
+
         init {
             options
                     .addOption(helpOption)
@@ -272,6 +312,15 @@ class ShuttleCliOptions {
                     .addOption(postgresOption)
                     .addOption(threadsOption)
                     .addOption(serverOption)
+                    .addOption(archiveOption)
+                    .addOption(startDateOption)
+                    .addOption(daysOption)
+
+            options.addOptionGroup(
+                OptionGroup()
+                    .addOption(importOption)
+                    .addOption(exportOption)
+            )
 
             options.addOptionGroup(
                     OptionGroup()

--- a/src/main/kotlin/com/openlattice/shuttle/ShuttleCliOptions.kt
+++ b/src/main/kotlin/com/openlattice/shuttle/ShuttleCliOptions.kt
@@ -255,9 +255,10 @@ class ShuttleCliOptions {
 
         private val archiveOption = Option.builder()
             .longOpt(ARCHIVE)
-            .hasArg(false)
-            .desc("Archive or import data between jdbc and s3")
-            .argName("archive")
+            .hasArg(true)
+            .desc("Archive or restore data between JDBC and s3.\n" +
+                    "\t--archive <\"export\" or \"import\"> --config </path/to/file.yaml> [--start-date --days]")
+            .argName("\"export\" or \"import\"")
             .build()
 
         private val startDateOption = Option.builder()
@@ -272,20 +273,6 @@ class ShuttleCliOptions {
             .hasArg(true)
             .desc("Indicates number of days from startDate to archive. Includes start date.")
             .argName("days")
-            .build()
-
-        private val exportOption = Option.builder()
-            .longOpt(EXPORT)
-            .hasArg(false)
-            .desc("Indicates export for archival")
-            .argName("export-archive")
-            .build()
-
-        private val importOption = Option.builder()
-            .longOpt(IMPORT)
-            .hasArg(false)
-            .desc("Indicates import for archival")
-            .argName("import-archive")
             .build()
 
         init {
@@ -315,12 +302,6 @@ class ShuttleCliOptions {
                     .addOption(archiveOption)
                     .addOption(startDateOption)
                     .addOption(daysOption)
-
-            options.addOptionGroup(
-                OptionGroup()
-                    .addOption(importOption)
-                    .addOption(exportOption)
-            )
 
             options.addOptionGroup(
                     OptionGroup()


### PR DESCRIPTION
**General**
Add capability to export / import data between s3 and Atlas via ShuttleCli. 

**Archive Methods**
There are two ways to archive data.
1. Chunked by date
2. The entire table

Chunked by date is preferred as it more transparently organizes data in s3. If the table does not have a date field or if uploading as a single table is preferable, then use the second method. To do this, do not provide a start-date argument — the entire table is uploaded if start-date is absent. 

**Usage**
- Indicate export / import by argument
- Indicate temporal details by argument
- Provide connection, source, and destination details in a YAML file

```
shuttle
        --archive export
        --config /path/to/config/file.yaml
        --start-date 2021-11-10
        --days 5
```

where
- `archive` specifies whether to import export
- `config`  defines path of the config file
- `start-date` (optional) is the date to begin (inclusive at 00:00)
- `days` (optional) is the number of days to integrate beginning at `state-date`. Default is `1`

Yaml file template:
```
archiveConfig:
  hikariConfig:
    jdbcUrl: "jdbcUrl"
    username: "user1234"
    password: "***"
    maximumPoolSize: 5
    connectionTimeout: 60000
  s3Bucket: "s3-bucket-name"
  s3Region: "s3-region-name"
  accessKey: "aws-access-key"
  secretKey: "aws-secret-key"
dbName: "org_my_db"
schemaName: "openlattice"
sourceName: "example_table"
destinationName: "example_table" # in most cases leave the same as sourceName
dateField: "column_name" # empty string if not needed
```

**S3 storage details**
Depending on which archive method one choses, s3 file names differ slightly.

File name structure when chunked by date: 
- `/archive01/$dbName/$schemaName/$destinationName/$destinationName_$date[_part$partNumber]`

File name structre when archiving the entire table:
- `/archive01/$dbName/$schemaName/$destinationName[_part$partNumber]`

**Current gotchas**
- Write validation isn't super helpful if data already exists for a given set of parameters
- Unchunked uploads greater than ~5000gb will likely fail. This is due to the pagination that occurs at very large loads and is currently unsupported by shuttle archiver. Chunking by date should make this a non-issue for the scale of data we handle.
- If data archived a second time, and the second time around there is less data than in the first archival, old, non-overwritten data may still exist. If that happens, importing will give a mix of old and current data. As a current workaround, use a new unique destinationName when archiving a second time with less data.
- Note that the Aurora extension to archive stores data in 5-6 GB files called "parts". So if 30 GB of data is uploaded with a destination of `foo`, then in s3 files will appear as `foo`, `foo_part2`, `foo_part3` and so on. The Shuttle archiver automatically imports all parts, so this behavior does not affect usage. 

**Potential Improvements**
- Better validation. Perhaps ensure that file size and/or row count match expectations. 
- Prevent old data from persisting when re-archiving 